### PR TITLE
Improve performance by using flat_map

### DIFF
--- a/lib/active_record_doctor/tasks/extraneous_indexes.rb
+++ b/lib/active_record_doctor/tasks/extraneous_indexes.rb
@@ -21,7 +21,7 @@ module ActiveRecordDoctor
         @extraneous_indexes ||=
           tables.reject do |table|
             "schema_migrations" == table
-          end.map do |table|
+          end.flat_map do |table|
             indexes = indexes(table)
             maximum_indexes = indexes.select do |index|
               indexes.all? do |another_index|
@@ -39,7 +39,7 @@ module ActiveRecordDoctor
                 end.name
               ]
             end
-          end.flatten(1)
+          end
       end
 
       def prefix?(lhs, rhs)


### PR DESCRIPTION
I've noticed you're using `map(...).flatten(1)` idiom, which isn't optimal.
Please find attached benchmark results and maybe consider using `flat_map` for better performance :)

```
require 'benchmark/ips'

ARRAY = (1..100).to_a

def slow_flatten_1
  ARRAY.map { |e| [e, e] }.flatten(1)
end

def slow_flatten
  ARRAY.map { |e| [e, e] }.flatten
end

def fast
  ARRAY.flat_map { |e| [e, e] }
end

Benchmark.ips do |x|
  x.report('Array#map.flatten(1)') { slow_flatten_1 }
  x.report('Array#map.flatten')    { slow_flatten   }
  x.report('Array#flat_map')       { fast           }
  x.compare!
end
```
(https://github.com/JuanitoFatas/fast-ruby/blob/master/code/enumerable/map-flatten-vs-flat_map.rb)

Run on my machine (1,4 GHz Intel Core i5, 4 GB 1600 MHz DDR3):
```
Calculating -------------------------------------
Array#map.flatten(1)     3.492k i/100ms
   Array#map.flatten     2.319k i/100ms
      Array#flat_map     4.281k i/100ms
-------------------------------------------------
Array#map.flatten(1)     35.503k (± 6.4%) i/s -    178.092k
   Array#map.flatten     23.547k (± 6.6%) i/s -    118.269k
      Array#flat_map     46.819k (± 5.0%) i/s -    235.455k

Comparison:
      Array#flat_map:    46818.8 i/s
Array#map.flatten(1):    35503.3 i/s - 1.32x slower
   Array#map.flatten:    23547.4 i/s - 1.99x slower
```

PS. Awesome gem!