### PR TITLE
Extraneous index check can skip fulltext indexes

### DIFF
--- a/lib/active_record_doctor/tasks/extraneous_indexes.rb
+++ b/lib/active_record_doctor/tasks/extraneous_indexes.rb
@@ -90,7 +90,7 @@ module ActiveRecordDoctor
       end
 
       def indexes(table_name)
-        @connection.indexes(table_name)
+        @connection.indexes(table_name).select {|i| i.columns.kind_of?(Array) }
       end
 
       def tables


### PR DESCRIPTION
ActiveRecord::ConnectionAdapters::IndexDefinition#columns returns a
String in the case of PostgreSQL full-text indexes, e.g.:

"to_tsvector('english'::regconfig, (first_name)::text)"

So those can be skipped for this analyzer.  Otherwise we get
ArgumentError: wrong number of arguments (given 0, expected 1+)
exceptions from ExtraneousIndex#prefix?.