### PR TITLE
Fix missing_non_null_constraint on null: true column with association

### DIFF
--- a/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
@@ -38,7 +38,7 @@ module ActiveRecordDoctor
 
         model.validators.any? do |validator|
           validator.is_a?(ActiveRecord::Validations::PresenceValidator) &&
-            (validator.attributes && allowed_attributes).present? &&
+            (validator.attributes & allowed_attributes).present? &&
             !validator.options[:allow_nil] &&
             !validator.options[:if] &&
             !validator.options[:unless]

--- a/test/active_record_doctor/tasks/missing_non_null_constraint_test.rb
+++ b/test/active_record_doctor/tasks/missing_non_null_constraint_test.rb
@@ -99,4 +99,18 @@ class ActiveRecordDoctor::Tasks::MissingNonNullConstraintTest < ActiveSupport::T
 
     assert_equal({}, run_task)
   end
+
+  def test_presence_true_with_null_true
+    Temping.create(:companies, temporary: false)
+    Temping.create(:users, temporary: false) do
+      belongs_to :company, required: true
+
+      with_columns do |t|
+        t.string :name, null: true
+        t.references :company, null: false
+      end
+    end
+
+    assert_equal({}, run_task)
+  end
 end


### PR DESCRIPTION
```bash
1) Failure:
ActiveRecordDoctor::Tasks::MissingNonNullConstraintTest#test_presence_true_with_null_true [active_record_doctor/test/active_record_doctor/tasks/missing_non_null_constraint_test.rb:114]:

Expected: {}
Actual: {"users"=>["name"]}
```