### PR TITLE
README: drop a "just" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ indexes on:
 * ...
 * `column_1, column_2, ..., column_(n - 1)`
 
-To discover such indexes automatically just follow these steps:
+To discover such indexes automatically, follow these steps:
 
 1. List extraneous indexes by running:
 


### PR DESCRIPTION
In order to make everyone welcome, we can keep the language as free of assumptions about the reader as we can.

---

(I made this PR for a CI run, now that there's a new Rails 5.2 out, the build failure on 2.2.10 could perhaps be solved by that. See #40 for that.)