### PR TITLE
Use Rails 5-2-stable branch to support Ruby 2.2.10

### DIFF
--- a/gemfiles/Gemfile.rails-5.2.x
+++ b/gemfiles/Gemfile.rails-5.2.x
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 gemspec path: File.join(File.dirname(__FILE__), '..')
 
-gem 'rails', '~> 5.2.0'
+gem 'rails', '~> 5.2', github: 'rails/rails', branch: '5-2-stable'


### PR DESCRIPTION
This PR is about fixing the build for Rails 5.2 on Ruby 2.2.10.

The released gem has a "safe navigation" in it. That's a 2.3 feature. 

The problem:

```
rake aborted!

SyntaxError: /home/travis/.rvm/gems/ruby-2.2.10/gems/actionpack-5.2.4.2/lib/action_dispatch/request/session.rb:96: syntax error, unexpected '.'

          id&.public_id

              ^
```