### PR TITLE
Fix undefined method subclasses

### DIFF
--- a/active_record_doctor.gemspec
+++ b/active_record_doctor.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", rails_version
   s.add_dependency "activerecord", rails_version
+  s.add_dependency "activesupport", rails_version
 
   s.add_development_dependency "rails", rails_version
   s.add_development_dependency "pg", "<= 0.20"

--- a/lib/active_record_doctor/tasks.rb
+++ b/lib/active_record_doctor/tasks.rb
@@ -1,3 +1,6 @@
+require "active_support"
+require "active_support/core_ext/class/subclasses"
+
 module ActiveRecordDoctor
   module Tasks
     def self.all


### PR DESCRIPTION
## Environment

ruby:2.7.1
rails:6.0.2.2

## Log

```
/usr/src/app # rails active_record_doctor
rails aborted!
NoMethodError: undefined method `subclasses' for ActiveRecordDoctor::Tasks::Base:Class
Did you mean?  superclass
/usr/local/bundle/gems/active_record_doctor-1.7.1/lib/active_record_doctor/tasks.rb:4:in `all'
/usr/local/bundle/gems/active_record_doctor-1.7.1/lib/tasks/active_record_doctor.rake:29:in `block in <main>'
/usr/local/bundle/gems/active_record_doctor-1.7.1/lib/tasks/active_record_doctor.rake:12:in `<main>'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:70:in `load'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:70:in `rescue in load'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:53:in `load'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:319:in `block in load'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:291:in `load_dependency'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:319:in `load'
/usr/local/bundle/gems/active_record_doctor-1.7.1/lib/active_record_doctor/railtie.rb:4:in `block in <class:Railtie>'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/railtie.rb:246:in `instance_exec'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/railtie.rb:246:in `block in run_tasks_blocks'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/railtie.rb:255:in `each'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/railtie.rb:255:in `each_registered_block'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/railtie.rb:246:in `run_tasks_blocks'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/application.rb:509:in `block in run_tasks_blocks'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/engine/railties.rb:15:in `each'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/engine/railties.rb:15:in `each'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/application.rb:509:in `run_tasks_blocks'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/engine.rb:459:in `load_tasks'
/usr/src/app/Rakefile:8:in `<main>'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:55:in `load'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:55:in `load'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:319:in `block in load'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:291:in `load_dependency'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:319:in `load'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/commands/rake/rake_command.rb:22:in `block in perform'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/command.rb:48:in `invoke'
/usr/local/bundle/gems/railties-6.0.2.2/lib/rails/commands.rb:18:in `<main>'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/usr/local/bundle/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:325:in `block in require'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:291:in `load_dependency'
/usr/local/bundle/gems/activesupport-6.0.2.2/lib/active_support/dependencies.rb:325:in `require'
bin/rails:4:in `<main>'

Caused by:
Bootsnap::LoadPathCache::FallbackScan:

(See full trace by running task with --trace)
```