### PR TITLE
Add support of discarded_at to unindexed_deleted_at task

### DIFF
--- a/lib/active_record_doctor/tasks/unindexed_deleted_at.rb
+++ b/lib/active_record_doctor/tasks/unindexed_deleted_at.rb
@@ -3,14 +3,16 @@ require "active_record_doctor/tasks/base"
 module ActiveRecordDoctor
   module Tasks
     class UnindexedDeletedAt < Base
+      COLUMNS = %w[deleted_at discarded_at].freeze
+      PATTERN = COLUMNS.join('|').freeze
       @description = 'Detect unindexed deleted_at columns'
 
       def run
         success(connection.tables.select do |table|
-          connection.columns(table).map(&:name).include?('deleted_at')
+          connection.columns(table).map(&:name).any?(/^#{PATTERN}$/)
         end.flat_map do |table|
           connection.indexes(table).reject do |index|
-            index.where =~ /\bdeleted_at\s+IS\s+NULL\b/i
+            index.where =~ /\b#{PATTERN}\s+IS\s+NULL\b/i
           end.map do |index|
             index.name
           end

--- a/test/active_record_doctor/tasks/unindexed_deleted_at_test.rb
+++ b/test/active_record_doctor/tasks/unindexed_deleted_at_test.rb
@@ -31,4 +31,33 @@ class ActiveRecordDoctor::Tasks::UnindexedDeletedAtTest < ActiveSupport::TestCas
 
     assert_result(['index_profiles_on_first_name_and_last_name'])
   end
+
+  def test_indexed_discarded_at_is_not_reported
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :first_name
+        t.string :last_name
+        t.datetime :discarded_at
+        t.index [:first_name, :last_name],
+          name: 'index_profiles_on_first_name_and_last_name',
+          where: 'discarded_at IS NULL'
+      end
+    end
+
+    assert_result([])
+  end
+
+  def test_unindexed_discarded_at_is_reported
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :first_name
+        t.string :last_name
+        t.datetime :discarded_at
+        t.index [:first_name, :last_name],
+          name: 'index_profiles_on_first_name_and_last_name'
+      end
+    end
+
+    assert_result(['index_profiles_on_first_name_and_last_name'])
+  end
 end


### PR DESCRIPTION
## Issue
> [paranoia](https://github.com/rubysherpas/paranoia) has some surprising behaviour (like overriding ActiveRecord's delete and destroy) and is not recommended for new projects. See [discard's README](https://github.com/jhawthorn/discard#why-not-paranoia-or-acts_as_paranoid) for more details.

## Solution
Add both `deleted_at` and `discarded_at` to the recipe.

Closes #42 