### PR TITLE
Not all validators respond to attributes

### DIFF
--- a/lib/active_record_doctor/tasks/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/tasks/missing_unique_indexes.rb
@@ -15,12 +15,12 @@ module ActiveRecordDoctor
             model.table_name,
             model.validators.select do |validator|
               table_name = model.table_name
-              attributes = validator.attributes
               scope = validator.options.fetch(:scope, [])
 
+              validator.respond_to?(:attributes) &&
               validator.is_a?(ActiveRecord::Validations::UniquenessValidator) &&
                 supported_validator?(validator) &&
-                !unique_index?(table_name, attributes, scope)
+                !unique_index?(table_name, validator.attributes, scope)
             end.map do |validator|
               scope = Array(validator.options.fetch(:scope, []))
               attributes = validator.attributes


### PR DESCRIPTION
```ruby
class Blah < ActiveModel::Validator
  def validate
  end
end
```

Not all validator subclasses respond to `attributes`. In these cases I think it's just easiest to skip em. Happy to add tests if you agree with the change.