### PR TITLE
Filter out descendants models without a backing table

### DIFF
--- a/lib/active_record_doctor/tasks/base.rb
+++ b/lib/active_record_doctor/tasks/base.rb
@@ -38,6 +38,10 @@ module ActiveRecordDoctor
           end
       end
 
+      def table_exists?(table_name)
+        connection.table_exists?(table_name)
+      end
+
       def views
         @views ||=
           if Rails::VERSION::MAJOR == 5
@@ -67,7 +71,7 @@ module ActiveRecordDoctor
       end
 
       def models
-        descendants(ActiveRecord::Base).select { |m| tables.include?(m.table_name) }
+        descendants(ActiveRecord::Base)
       end
 
       def descendants(superclass)

--- a/lib/active_record_doctor/tasks/base.rb
+++ b/lib/active_record_doctor/tasks/base.rb
@@ -67,7 +67,7 @@ module ActiveRecordDoctor
       end
 
       def models
-        descendants(ActiveRecord::Base)
+        descendants(ActiveRecord::Base).select { |m| tables.include?(m.table_name) }
       end
 
       def descendants(superclass)

--- a/lib/active_record_doctor/tasks/incorrect_boolean_presence_validation.rb
+++ b/lib/active_record_doctor/tasks/incorrect_boolean_presence_validation.rb
@@ -9,7 +9,9 @@ module ActiveRecordDoctor
         eager_load!
 
         success(hash_from_pairs(models.reject do |model|
-          model.table_name.nil? || model.table_name == 'schema_migrations'
+          model.table_name.nil? ||
+          model.table_name == 'schema_migrations' ||
+          !table_exists?(model.table_name)
         end.map do |model|
           [
             model.name,

--- a/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
@@ -9,7 +9,9 @@ module ActiveRecordDoctor
         eager_load!
 
         success(hash_from_pairs(models.reject do |model|
-          model.table_name.nil? || model.table_name == 'schema_migrations'
+          model.table_name.nil? ||
+          model.table_name == 'schema_migrations' ||
+          !table_exists?(model.table_name)
         end.map do |model|
           [
             model.table_name,

--- a/lib/active_record_doctor/tasks/missing_presence_validation.rb
+++ b/lib/active_record_doctor/tasks/missing_presence_validation.rb
@@ -9,7 +9,9 @@ module ActiveRecordDoctor
         eager_load!
 
         success(hash_from_pairs(models.reject do |model|
-          model.table_name.nil? || model.table_name == 'schema_migrations'
+          model.table_name.nil? ||
+          model.table_name == 'schema_migrations' ||
+          !table_exists?(model.table_name)
         end.map do |model|
           [
             model.name,


### PR DESCRIPTION
`IncorrectBooleanPresenceValidation`, `MissingPresenceValidation` and other checks assume that the models, computed enumerating the descendants of `ActiveRecord::Base` all have a correspondent table in the database, but this is not always the case.

If a model is inherited from a model in a gem and the table name is changed, both will appear in the `descendants` but the former won't have an actual DB table to scan and thus break the check. For example:

```shell
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "settings" does not exist
LINE 8:  WHERE a.attrelid = '"settings"'::regclass
...
/Users/rhymes/.gem/ruby/2.7.1/gems/active_record_doctor-1.7.1/lib/active_record_doctor/tasks/incorrect_boolean_presence_validation.rb:14:in `block in run'
...
```

this happens because [we have a model](https://github.com/forem/forem/blob/master/app/models/site_config.rb) defined like this:

```ruby
class SiteConfig < RailsSettings::Base
  self.table_name = "site_configs"
  ...
end
```

so both `SiteConfig` and `RailsSettings::Base` appear in the descendants, as `RailsSettings::Base` is [defined like this](https://github.com/huacnlee/rails-settings-cached/blob/b36bdaf4ae76eae0ba651a36a21752197d735fc3/lib/rails-settings/base.rb#L5-L10):

```ruby
module RailsSettings
  class Base < ActiveRecord::Base
    self.table_name = table_name_prefix + "settings"
```

as we override `table_name` in our model, the active record doctor check will also try to inspect the parent model.

I thus decided to filter out models whose `table_name` doesn't appear in the scripts that need it