### PR TITLE
Columns ordering in missing unique index validation should not matter

### DIFF
--- a/lib/active_record_doctor/tasks/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/tasks/missing_unique_indexes.rb
@@ -49,7 +49,7 @@ module ActiveRecordDoctor
         columns = (Array(scope) + columns).map(&:to_s)
 
         indexes(table_name).any? do |index|
-          index.columns == columns && index.unique
+          index.columns.to_set == columns.to_set && index.unique
         end
       end
     end


### PR DESCRIPTION
Right now if the uniqueness validator is `[:a, :b, :c]` but the unique index is `[:a, :c:, :b]` this checks fails, but the order is not strictly important. It can be regarding how databases behave in their query plan, for the Rails purposes is not important.

I need help with the tests, should I just add a new case?