### PR TITLE
Add Dependent delete or destroy task

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ can:
 * detect missing non-`NULL` constraints - [`active_record_doctor:missing_non_null_constraint`](#detecting-missing-non-null-constraints)
 * detect missing presence validations - [`active_record_doctor:missing_presence_validation`](#detecting-missing-presence-validations)
 * detect incorrect presence validations on boolean columns - [`active_record_doctor:incorrect_boolean_presence_validation`](#detecting-incorrect-presence-validations-on-boolean-columns)
+* detect incorrect values of `dependent` on associations - [`active_record_doctor:incorrect_dependent_option`](#detecting-incorrect-dependent-option-on-associations)
 
 More features coming soon!
 
@@ -283,6 +284,34 @@ This means `active` is validated with `presence: true` instead of
 `inclusion: { in: [true, false] }` or `exclusion: { in: [nil] }`.
 
 This validator skips models whose corresponding database tables don't exist.
+
+### Detecting Incorrect `dependent` Option on Associations
+
+Cascading model deletions can be sped up with `dependent: :delete_all` (to
+delete all dependent models with one SQL query) but only if the deleted models
+have no callbacks as they're skipped.
+
+This can lead to two types of errors:
+
+- Using `delete_all` when dependent models define callbacks - they will NOT be
+  invoked.
+- Using `destroy` when dependent models define no callbacks - dependent models
+  will be loaded one-by-one with no reason
+
+In order to detect associations affected by the two aforementioned problems run
+the following command:
+
+```
+bundle exec rake active_record_doctor:incorrect_dependent_option
+```
+
+The output of the command looks like this:
+
+```
+The following associations might be using invalid dependent settings:
+  Company: users loads models one-by-one to invoke callbacks even though the related model defines none - consider using `dependent: :delete_all`
+  Post: comments skips callbacks that are defined on the associated model - consider changing to `dependent: :destroy` or similar
+```
 
 ## Ruby and Rails Compatibility Policy
 

--- a/lib/active_record_doctor.rb
+++ b/lib/active_record_doctor.rb
@@ -14,6 +14,7 @@ require "active_record_doctor/detectors/unindexed_deleted_at"
 require "active_record_doctor/detectors/undefined_table_references"
 require "active_record_doctor/detectors/missing_non_null_constraint"
 require "active_record_doctor/detectors/unindexed_foreign_keys"
+require "active_record_doctor/detectors/incorrect_dependent_option"
 require "active_record_doctor/task"
 require "active_record_doctor/version"
 

--- a/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
+++ b/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "active_record_doctor/detectors/base"
+
+module ActiveRecordDoctor
+  module Detectors
+    # Find has_many/has_one associations with dependent options not taking the
+    # related model's callbacks into account.
+    class IncorrectDependentOption < Base
+      # rubocop:disable Layout/LineLength
+      @description = "Detect associations that should use a different dependent option based on callbacks on the related model"
+      # rubocop:enable Layout/LineLength
+
+      def run
+        eager_load!
+
+        success(hash_from_pairs(models.reject do |model|
+          model.table_name.nil?
+        end.map do |model|
+          [
+            model.name,
+            associations_with_incorrect_dependent_options(model)
+          ]
+        end.reject do |_model_name, associations|
+          associations.empty?
+        end))
+      end
+
+      private
+
+      def associations_with_incorrect_dependent_options(model)
+        reflections = model.reflect_on_all_associations(:has_many) + model.reflect_on_all_associations(:has_one)
+        reflections.map do |reflection|
+          if callback_action(reflection) == :invoke && !defines_destroy_callbacks?(reflection.klass)
+            [reflection.name, :callbacks_missing]
+          elsif callback_action(reflection) == :skip && defines_destroy_callbacks?(reflection.klass)
+            [reflection.name, :callbacks_skipped]
+          end
+        end.compact
+      end
+
+      def callback_action(reflection)
+        case reflection.options[:dependent]
+        when :delete_all then :skip
+        when :destroy then :invoke
+        end
+      end
+
+      def defines_destroy_callbacks?(model)
+        # Destroying an associated model involves loading it first hence
+        # initialize and find are present. If they are defined on the model
+        # being deleted then theoretically we can't use :delete_all. It's a bit
+        # of an edge case as they usually are either absent or have no side
+        # effects but we're being pedantic -- they could be used for audit
+        # trial, for instance, and we don't want to skip that.
+        model._initialize_callbacks.present? ||
+          model._find_callbacks.present? ||
+          model._destroy_callbacks.present? ||
+          model._commit_callbacks.present? ||
+          model._rollback_callbacks.present?
+      end
+    end
+  end
+end

--- a/lib/active_record_doctor/printers/io_printer.rb
+++ b/lib/active_record_doctor/printers/io_printer.rb
@@ -107,6 +107,26 @@ WARNING
           @io.puts("  #{table}: #{columns.join(', ')}")
         end
       end
+
+      def incorrect_dependent_option(problems)
+        return if problems.empty?
+
+        @io.puts("The following associations might be using invalid dependent settings:")
+        problems.each do |model, associations|
+          associations.each do |(name, problem)|
+            # rubocop:disable Layout/LineLength
+            message =
+              case problem
+              when :callbacks_skipped then "skips callbacks that are defined on the associated model - consider changing to `dependent: :destroy` or similar"
+              when :callbacks_missing then "loads models one-by-one to invoke callbacks even though the related model defines none - consider using `dependent: :delete_all`"
+              else next
+              end
+            # rubocop:enable Layout/LineLength
+
+            @io.puts("  #{model}: #{name} #{message}")
+          end
+        end
+      end
     end
   end
 end

--- a/lib/tasks/active_record_doctor.rake
+++ b/lib/tasks/active_record_doctor.rake
@@ -10,6 +10,7 @@ require "active_record_doctor/detectors/missing_unique_indexes"
 require "active_record_doctor/detectors/missing_presence_validation"
 require "active_record_doctor/detectors/missing_non_null_constraint"
 require "active_record_doctor/detectors/incorrect_boolean_presence_validation"
+require "active_record_doctor/detectors/incorrect_dependent_option"
 require "active_record_doctor/task"
 
 namespace :active_record_doctor do

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -7,3 +7,7 @@ inherit_from:
 # causes them to be indented without any benefit.
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
+
+# Some test models need methods defined on them in a #create_model block.
+Lint/NestedMethodDefinition:
+  Enabled: false

--- a/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+class ActiveRecordDoctor::Detectors::IncorrectDependentOptionTest < Minitest::Test
+  def test_invoking_no_callbacks_suggests_delete_all
+    create_table(:companies) do
+    end.create_model do
+      has_many :users, dependent: :destroy
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+    end
+
+    assert_success(<<OUTPUT)
+The following associations might be using invalid dependent settings:
+  ModelFactory::Models::Company: users loads models one-by-one to invoke callbacks even though the related model defines none - consider using `dependent: :delete_all`
+OUTPUT
+  end
+
+  def test_invoking_callbacks_does_not_suggest_delete_all
+    create_table(:companies) do
+    end.create_model do
+      has_many :users, dependent: :destroy
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+
+      before_destroy :log
+
+      def log
+      end
+    end
+
+    assert_success("")
+  end
+
+  def test_skipping_callbacks_suggests_destroy
+    create_table(:companies) do
+    end.create_model do
+      has_many :users, dependent: :delete_all
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+
+      before_destroy :log
+
+      def log
+      end
+    end
+
+    assert_success(<<OUTPUT)
+The following associations might be using invalid dependent settings:
+  ModelFactory::Models::Company: users skips callbacks that are defined on the associated model - consider changing to `dependent: :destroy` or similar
+OUTPUT
+  end
+
+  def test_invoking_callbacks_does_not_suggest_destroy
+    create_table(:companies) do
+    end.create_model do
+      has_many :users, dependent: :destroy
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+
+      before_destroy :log
+
+      def log
+      end
+    end
+
+    assert_success("")
+  end
+
+  def test_works_on_has_one
+    create_table(:companies) do
+    end.create_model do
+      has_one :owner, class_name: "ModelFactory::Models::User", dependent: :destroy
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+    end
+
+    assert_success(<<OUTPUT)
+The following associations might be using invalid dependent settings:
+  ModelFactory::Models::Company: owner loads models one-by-one to invoke callbacks even though the related model defines none - consider using `dependent: :delete_all`
+OUTPUT
+  end
+
+  def test_no_dependent_suggests_nothing
+    create_table(:companies) do
+    end.create_model do
+      has_many :users
+    end
+
+    create_table(:users) do |t|
+      t.references :companies
+    end.create_model do
+      belongs_to :company
+    end
+
+    assert_success("")
+  end
+end


### PR DESCRIPTION
It is faster to use `has_many :comments, dependent: :delete_all` than `has_many :comments, dependent: :destroy` since it will not load each comment (N+1 query).
But if comment has another dependencies (for example `has_many :tags`) than we should keep using `has_many :comments, dependent: :destroy`. This task helps to find such places where we can speed up deletion. Also it finds places where `has_many :comments, dependent: :delete_all` is used, but associated model contains other `has_many` relations or `_destroy` callbacks.