### PR TITLE
Add compatibility with pg_search

### DIFF
--- a/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/tasks/missing_non_null_constraint.rb
@@ -10,6 +10,8 @@ module ActiveRecordDoctor
 
         success(hash_from_pairs(models.reject do |model|
           model.table_name.nil? || model.table_name == 'schema_migrations'
+        end.reject do |model|
+          model.table_name == 'pg_search_documents'
         end.map do |model|
           [
             model.table_name,

--- a/lib/active_record_doctor/tasks/missing_presence_validation.rb
+++ b/lib/active_record_doctor/tasks/missing_presence_validation.rb
@@ -10,6 +10,8 @@ module ActiveRecordDoctor
 
         success(hash_from_pairs(models.reject do |model|
           model.table_name.nil? || model.table_name == 'schema_migrations'
+        end.reject do |model|
+          model.table_name == 'pg_search_documents'
         end.map do |model|
           [
             model.name,


### PR DESCRIPTION
Hello!

I have noticed that detecting missing presence validations and detecting missing non-`NULL` constraints don't have compatibility with [pg_search](https://github.com/Casecommons/pg_search) gem. When I run rake-task I get error 

```
Caused by:
PG::UndefinedTable: ERROR:  relation "pg_search_documents" does not exist
LINE 5:                WHERE a.attrelid = '"pg_search_documents"'::r...
```

It is the easiest workaround to solve the problem.

What do you think about it? Maybe you have a better idea :)