### PR TITLE
Use shorter name if index name is too long

### DIFF
--- a/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
+++ b/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
@@ -56,7 +56,14 @@ MIGRATION
     end
 
     def add_index(table, column)
-      "    add_index :#{table}, :#{column}"
+      index_name = Class.new.extend(ActiveRecord::ConnectionAdapters::SchemaStatements).index_name table, column
+      # rubocop:disable Layout/LineLength
+      if index_name.size > ActiveRecord::Base.connection.allowed_index_name_length
+        "    add_index :#{table}, :#{column}, name: '#{index_name.first ActiveRecord::Base.connection.allowed_index_name_length}'"
+      else
+        "    add_index :#{table}, :#{column}"
+      end
+      # rubocop:enable Layout/LineLength
     end
 
     def migration_version


### PR DESCRIPTION
To prevent exceptions like
```
StandardError: An error has occurred, all later migrations canceled:

Index name 'index_deleted_subscriber_invoice_status_transitions_on_subscriber_invoice_id' on table 'deleted_subscriber_invoice_status_transitions' is too long; the limit is 64 characters
```

we should suggest shorter name