### PR TITLE
Add a missing migration version to the generated migration file for Rails 6.0

### DIFF
--- a/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
+++ b/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
@@ -54,10 +54,9 @@ EOF
     end
 
     def migration_version
-      major = ActiveRecord::VERSION::MAJOR
-      minor = ActiveRecord::VERSION::MINOR
-      if major >= 5 && minor >= 1
-        "[#{major}.#{minor}]"
+      version = ActiveRecord::VERSION::STRING.to_f
+      if version >= 5.1
+        "[#{version}]"
       else
         ''
       end


### PR DESCRIPTION
In Rails 6.0, `rails generate active_record_doctor:add_indexes` command generates a migration file without a migration version:

```
$ bin/rails --version
Rails 6.0.3.6
$ bin/rails generate active_record_doctor:add_indexes unindexed_foreign_keys.txt
$ cat db/migrate/20210401171205_index_foreign_keys_in_books.rb
class IndexForeignKeysInBooks < ActiveRecord::Migration
  def change
    add_index :books, :author_id
  end
end
$
```

This patch fixes the issue.