### PR TITLE
work with ActiveRecord::VERSION::MAJOR >= 5 (not just == 5)

### DIFF
--- a/lib/active_record_doctor/tasks/base.rb
+++ b/lib/active_record_doctor/tasks/base.rb
@@ -31,7 +31,7 @@ module ActiveRecordDoctor
 
       def tables
         @tables ||=
-          if ActiveRecord::VERSION::MAJOR == 5
+          if ActiveRecord::VERSION::MAJOR >= 5
             connection.data_sources
           else
             connection.tables
@@ -44,7 +44,7 @@ module ActiveRecordDoctor
 
       def views
         @views ||=
-          if ActiveRecord::VERSION::MAJOR == 5
+          if ActiveRecord::VERSION::MAJOR >= 5
             connection.views
           elsif connection.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
             ActiveRecord::Base.connection.execute(<<-SQL).map { |tuple| tuple.fetch("relname") }

--- a/lib/active_record_doctor/version.rb
+++ b/lib/active_record_doctor/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordDoctor
-  VERSION = "1.7.2"
+  VERSION = "1.7.2.1"
 end


### PR DESCRIPTION
was using Active Record Doctor with a Rails 6 project and ran into a snag -- it was checking for Rails == 5.  simply changed this check to >= 5 in order to get it to work with Rails 6.