### PR TITLE
Fix AddIndexesGenerator migration versioning

### DIFF
--- a/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
+++ b/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
@@ -61,7 +61,7 @@ MIGRATION
 
     def migration_version
       if ActiveRecord::VERSION::STRING >= "5.1"
-        "[#{version}]"
+        "[#{ActiveRecord::Migration.current_version}]"
       else
         ""
       end


### PR DESCRIPTION
Before, running the generator breaks since 50c1191100 due to the mention
of an undefined `version` method.
This commit uses Migration subclasses as Rails does (see https://github.com/rails/rails/commit/6940dc860c4b25bff2eded370f2af4316de15a30)

I'd be happy to work in a separate PR on tests for the existing generator, and introducing others.
Is there any plans related or work already started I can help with @gregnavis?