### PR TITLE
Ignore automatically generated HABTM models

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -87,7 +87,8 @@ module ActiveRecordDoctor
       end
 
       def models
-        ActiveRecord::Base.descendants
+        # Ignore auto-generated models by Active Record has_and_belongs_to_many macro
+        ActiveRecord::Base.descendants.reject { |model| model.name.start_with?("HABTM_") }
       end
     end
   end

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -42,6 +42,31 @@ OUTPUT
     refute_problems
   end
 
+  def test_not_null_column_is_not_reported_if_habtm_association
+    create_table(:users).create_model do
+      def self.name
+        "ModelFactory::Models::User"
+      end
+
+      has_and_belongs_to_many :projects, class_name: "ModelFactory::Models::Project"
+    end
+
+    create_table(:projects_users) do |t|
+      t.bigint :project_id, null: false
+      t.bigint :user_id, null: false
+    end
+
+    create_table(:projects).create_model do
+      def self.name
+        "ModelFactory::Models::Project"
+      end
+
+      has_and_belongs_to_many :users, class_name: "ModelFactory::Models::User"
+    end
+
+    refute_problems
+  end
+
   def test_non_null_boolean_is_reported_if_nil_included
     create_table(:users) do |t|
       t.boolean :active, null: false

--- a/test/model_factory.rb
+++ b/test/model_factory.rb
@@ -53,7 +53,7 @@ module ModelFactory
   def self.create_model(table_name, &block)
     table_name = table_name.to_sym
     klass = Class.new(ActiveRecord::Base, &block)
-    klass_name = table_name.to_s.classify
+    klass_name = table_name.to_s.singularize.classify
     Models.const_set(klass_name, klass)
   end
 


### PR DESCRIPTION
Rails' `has_and_belongs_to_many` automatically [creates](https://github.com/rails/rails/blob/ce546c7d3a867dce11e7b99624160a7388bee1f5/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb#L14) intermediate models, which should really not be checked.

Closes #67