### PR TITLE
Ignore STI models in MissingNonNullConstraint detector

### DIFF
--- a/lib/active_record_doctor/config/default.rb
+++ b/lib/active_record_doctor/config/default.rb
@@ -30,8 +30,8 @@ ActiveRecordDoctor.configure do
     ignore_columns: []
 
   detector :missing_non_null_constraint,
-    ignore_models: [],
-    ignore_attributes: []
+    ignore_tables: [],
+    ignore_columns: []
 
   detector :missing_presence_validation,
     ignore_models: [],

--- a/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
+++ b/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Test
-  def test_presence_true_and_null_true
+  def test_optional_columns_with_presence_validator_are_disallowed
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -9,24 +9,24 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     end
 
     assert_problems(<<~OUTPUT)
-      add `NOT NULL` to users.name - ModelFactory::Models::User validates its presence but it's not non-NULL in the database
+      add `NOT NULL` to users.name - models validates its presence but it's not non-NULL in the database
     OUTPUT
   end
 
-  def test_association_presence_true_and_null_true
+  def test_optional_foreign_keys_with_required_association_are_disallowed
     create_table(:companies)
     create_table(:users) do |t|
-      t.references :company
+      t.references :company, null: true
     end.create_model do
       belongs_to :company, required: true
     end
 
     assert_problems(<<~OUTPUT)
-      add `NOT NULL` to users.company_id - ModelFactory::Models::User validates its presence but it's not non-NULL in the database
+      add `NOT NULL` to users.company_id - models validates its presence but it's not non-NULL in the database
     OUTPUT
   end
 
-  def test_presence_true_and_null_false
+  def test_required_columns_with_presence_validators_are_allowed
     create_table(:users) do |t|
       t.string :name, null: false
     end.create_model do
@@ -36,7 +36,17 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
-  def test_presence_false_and_null_true
+  def test_optional_columns_without_presence_validator_are_allowed
+    create_table(:users) do |t|
+      t.string :name, null: false
+    end.create_model do
+      validates :name, presence: false
+    end
+
+    refute_problems
+  end
+
+  def test_validators_matched_to_correct_columns
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -52,17 +62,7 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
-  def test_presence_false_and_null_false
-    create_table(:users) do |t|
-      t.string :name, null: false
-    end.create_model do
-      validates :name, presence: false
-    end
-
-    refute_problems
-  end
-
-  def test_presence_true_with_if
+  def test_validators_with_if_on_optional_columns_are_allowed
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -72,7 +72,7 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
-  def test_presence_true_with_unless
+  def test_validators_with_unless_on_optional_columns_are_allowed
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -82,7 +82,7 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
-  def test_presence_true_with_allow_nil
+  def test_validators_allowing_nil_on_optional_columns_are_allowed
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -98,7 +98,73 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
-  def test_config_ignore_models
+  def test_optional_columns_validated_by_all_sti_models_are_disallowed
+    create_table(:users) do |t|
+      t.string :type, null: false
+      t.string :email, null: true
+    end.create_model
+
+    create_model(:Client, ModelFactory::Models::User) do
+      validates :email, presence: true
+    end
+
+    assert_problems(<<~OUTPUT)
+      add `NOT NULL` to users.email - models validates its presence but it's not non-NULL in the database
+    OUTPUT
+  end
+
+  def test_optional_columns_validated_by_some_sti_models_are_allowed
+    create_table(:users) do |t|
+      t.string :type, null: false
+      t.string :email, null: true
+    end.create_model
+
+    create_model(:Client, ModelFactory::Models::User) do
+      validates :email, presence: true
+    end
+
+    create_model(:Admin, ModelFactory::Models::User) do
+      validates :email, presence: false
+    end
+
+    refute_problems
+  end
+
+  def test_optional_columns_validated_by_all_non_sti_models_are_disallowed
+    create_table(:users) do |t|
+      t.string :email, null: true
+    end.create_model do
+      validates :email, presence: true
+    end
+
+    create_model(:Client) do
+      self.table_name = :users
+
+      validates :email, presence: true
+    end
+
+    assert_problems(<<~OUTPUT)
+      add `NOT NULL` to users.email - models validates its presence but it's not non-NULL in the database
+    OUTPUT
+  end
+
+  def test_optional_columns_validated_by_some_non_sti_models_are_allowed
+    create_table(:users) do |t|
+      t.string :email, null: true
+    end.create_model do
+      validates :email, presence: true
+    end
+
+    create_model(:Client) do
+      self.table_name = :users
+
+      validates :email, presence: false
+    end
+
+    refute_problems
+  end
+
+  def test_config_ignore_tables
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -108,14 +174,14 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     config_file(<<-CONFIG)
       ActiveRecordDoctor.configure do |config|
         config.detector :missing_non_null_constraint,
-          ignore_models: ["ModelFactory::Models::User"]
+          ignore_tables: ["users"]
       end
     CONFIG
 
     refute_problems
   end
 
-  def test_global_ignore_models
+  def test_global_ignore_tables
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -124,14 +190,14 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
 
     config_file(<<-CONFIG)
       ActiveRecordDoctor.configure do |config|
-        config.global :ignore_models, ["ModelFactory::Models::User"]
+        config.global :ignore_tables, ["users"]
       end
     CONFIG
 
     refute_problems
   end
 
-  def test_config_ignore_attributes
+  def test_config_ignore_columns
     create_table(:users) do |t|
       t.string :name, null: true
     end.create_model do
@@ -141,7 +207,7 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     config_file(<<-CONFIG)
       ActiveRecordDoctor.configure do |config|
         config.detector :missing_non_null_constraint,
-          ignore_attributes: ["ModelFactory::Models::User.name"]
+          ignore_columns: ["users.name"]
       end
     CONFIG
 


### PR DESCRIPTION
When using STI, models share the same table and we should generate a warning only for a parent class.

Fixes #73