### PR TITLE
Accept uuid as long primary key type

### DIFF
--- a/lib/active_record_doctor/detectors/short_primary_key_type.rb
+++ b/lib/active_record_doctor/detectors/short_primary_key_type.rb
@@ -23,7 +23,7 @@ module ActiveRecordDoctor
         tables(except: config(:ignore_tables)).each do |table|
           column = primary_key(table)
           next if column.nil?
-          next if bigint?(column)
+          next if bigint?(column) || uuid?(column)
 
           problem!(table: table, column: column.name)
         end
@@ -35,6 +35,10 @@ module ActiveRecordDoctor
         else
           /\Abigint\b/.match?(column.sql_type)
         end
+      end
+
+      def uuid?(column)
+        column.sql_type == "uuid"
       end
     end
   end


### PR DESCRIPTION
This PR fixes this CI failure - https://github.com/gregnavis/active_record_doctor/runs/4775054306?check_suite_focus=true#step:6:20

And also adds a check for `uuid` primary key type to `ShortPrimaryKeyType`. It was added before (https://github.com/gregnavis/active_record_doctor/commit/a96e26b08dde0d1e98ca196ea0f5b50be3798e1f#diff-b462e6b0c496090ec5749009df0892da4ba6cf3d25ec16fa19269191bf10686eR10), seems like you accidentally removed it.