### PR TITLE
Accept NOT NULL check constraints for `MissingNonNullConstraint` detector

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -129,6 +129,13 @@ module ActiveRecordDoctor
           end
       end
 
+      def not_null_check_constraint_exists?(table, column)
+        check_constraints(table).any? do |definition|
+          definition =~ /\A#{column.name} IS NOT NULL\z/i ||
+            definition =~ /\A#{connection.quote_column_name(column.name)} IS NOT NULL\z/i
+        end
+      end
+
       def check_constraints(table_name)
         # ActiveRecord 6.1+
         if connection.respond_to?(:supports_check_constraints?) && connection.supports_check_constraints?

--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -68,13 +68,6 @@ module ActiveRecordDoctor
             !validator.options[:unless]
         end
       end
-
-      def not_null_check_constraint_exists?(table, column)
-        check_constraints(table).any? do |definition|
-          definition =~ /\A#{column.name} IS NOT NULL\z/i ||
-            definition =~ /\A#{connection.quote_column_name(column.name)} IS NOT NULL\z/i
-        end
-      end
     end
   end
 end

--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -38,7 +38,7 @@ module ActiveRecordDoctor
 
       def validator_needed?(model, column)
         ![model.primary_key, "created_at", "updated_at"].include?(column.name) &&
-          !column.null
+          (!column.null || not_null_check_constraint_exists?(model.table_name, column))
       end
 
       def validator_present?(model, column)


### PR DESCRIPTION
Closes #83

While technically mysql/mariadb, sqlite3 and some others support check constraints, I have seen this trick is only applied to postgres databases, as commented in the issue. So added a raw query for rails < 6.1 only for postgres, to make the implementation simple. 

`if connection.respond_to?(:supports_check_constraints?) && connection.supports_check_constraints?` branch should cover everything else.

@owst