### PR TITLE
Fix typo in Missing Presence Validations config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ This validator skips models whose corresponding database tables don't exist.
 Supported configuration options:
 
 - `ignore_models` - models whose underlying tables' columns should not be checked.
-- `ignore_columns` - specific attributes, written as Model.attribute, that should not be checked.
+- `ignore_attributes` - specific attributes, written as Model.attribute, that should not be checked.
 
 ### Detecting Incorrect Presence Validations on Boolean Columns
 


### PR DESCRIPTION
It looks like the correct configuration option according to the tests is `ignore_attributes`.

Source:

https://github.com/gregnavis/active_record_doctor/blob/32906dc95f4343290c237026596a535c7348351f/test/active_record_doctor/detectors/missing_presence_validation_test.rb#L153-L168