### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,8 @@ jobs:
             gemfile: gemfiles/Gemfile.rails-7.0.x
           - ruby-version: 3.0.2
             gemfile: gemfiles/Gemfile.rails-7.0.x
+          - ruby-version: 3.1.1
+            gemfile: gemfiles/Gemfile.rails-7.0.x
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
This adds a single entry for Ruby 3.1 / Rails 7.0.