### PR TITLE
Ignore abstract model classes

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -131,7 +131,9 @@ module ActiveRecordDoctor
 
       def models(except: [])
         ActiveRecord::Base.descendants.reject do |model|
-          model.name.start_with?("HABTM_") || except.include?(model.name)
+          model.abstract_class? ||
+            model.name.start_with?("HABTM_") ||
+            except.include?(model.name)
         end
       end
 

--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -29,9 +29,7 @@ module ActiveRecordDoctor
         table_models.each do |table, models|
           next if config(:ignore_tables).include?(table)
 
-          concrete_models = models.reject do |model|
-            model.abstract_class? || sti_base_model?(model)
-          end
+          concrete_models = models.reject { |model| sti_base_model?(model) }
 
           connection.columns(table).each do |column|
             next if config(:ignore_columns).include?("#{table}.#{column.name}")

--- a/test/active_record_doctor/detectors/undefined_table_references_test.rb
+++ b/test/active_record_doctor/detectors/undefined_table_references_test.rb
@@ -30,6 +30,14 @@ class ActiveRecordDoctor::Detectors::UndefinedTableReferencesTest < Minitest::Te
     end
   end
 
+  def test_abstract_model
+    create_model(:ApplicationRecord) do
+      self.abstract_class = true
+    end
+
+    refute_problems
+  end
+
   def test_config_ignore_tables
     create_model(:User)
 


### PR DESCRIPTION
```bash
$ rake active_record_doctor
```

Got this warning, among others:
```
ApplicationRecord references a non-existent table or view named
```