### PR TITLE
Allow models to be backed by foreign tables in PostgreSQL for undefined_table_references

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -121,24 +121,6 @@ module ActiveRecordDoctor
         connection.columns(table_name).find { |column| column.name == column_name }
       end
 
-      def views
-        @views ||=
-          if connection.respond_to?(:views)
-            connection.views
-          elsif postgresql?
-            ActiveRecord::Base.connection.select_values(<<-SQL)
-              SELECT relname FROM pg_class WHERE relkind IN ('m', 'v')
-            SQL
-          elsif connection.adapter_name == "Mysql2"
-            ActiveRecord::Base.connection.select_values(<<-SQL)
-              SHOW FULL TABLES WHERE table_type = 'VIEW'
-            SQL
-          else
-            # We don't support this Rails/database combination yet.
-            []
-          end
-      end
-
       def not_null_check_constraint_exists?(table, column)
         check_constraints(table).any? do |definition|
           definition =~ /\A#{column.name} IS NOT NULL\z/i ||

--- a/lib/active_record_doctor/detectors/undefined_table_references.rb
+++ b/lib/active_record_doctor/detectors/undefined_table_references.rb
@@ -21,7 +21,7 @@ module ActiveRecordDoctor
 
       def detect
         models(except: config(:ignore_models)).each do |model|
-          next if model.table_exists? || views.include?(model.table_name)
+          next if connection.data_source_exists?(model.table_name)
 
           problem!(model: model.name, table: model.table_name)
         end


### PR DESCRIPTION
We can avoid creating our own method to get the VIEWs, since `data_source_exists?` already does this. And additionally this will allow for models to be backed by foreign tables in PostgreSQL.

https://github.com/rails/rails/blob/be400c3ca2b86111766d840979478fc026679368/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L882-L909