### PR TITLE
Accept `deleted_at IS NOT NULL` partial indexes for unindexed_deleted_at

### DIFF
--- a/lib/active_record_doctor/detectors/unindexed_deleted_at.rb
+++ b/lib/active_record_doctor/detectors/unindexed_deleted_at.rb
@@ -26,7 +26,7 @@ module ActiveRecordDoctor
 
       def message(index:, column_name:)
         # rubocop:disable Layout/LineLength
-        "consider adding `WHERE #{column_name} IS NULL` to #{index} - a partial index can speed lookups of soft-deletable models"
+        "consider adding `WHERE #{column_name} IS NULL` or `WHERE #{column_name} IS NOT NULL` to #{index} - a partial index can speed lookups of soft-deletable models"
         # rubocop:enable Layout/LineLength
       end
 
@@ -42,8 +42,7 @@ module ActiveRecordDoctor
 
           timestamp_columns.each do |timestamp_column|
             indexes(table, except: config(:ignore_indexes)).each do |index|
-              # TODO: whole word
-              next if index.where =~ /\b#{timestamp_column.name}\s+IS\s+NULL\b/i
+              next if index.where =~ /\b#{timestamp_column.name}\s+IS\s+(NOT\s+)?NULL\b/i
 
               problem!(index: index.name, column_name: timestamp_column.name)
             end

--- a/test/active_record_doctor/detectors/unindexed_deleted_at_test.rb
+++ b/test/active_record_doctor/detectors/unindexed_deleted_at_test.rb
@@ -11,6 +11,9 @@ class ActiveRecordDoctor::Detectors::UnindexedDeletedAtTest < Minitest::Test
       t.index [:first_name, :last_name],
         name: "index_profiles_on_first_name_and_last_name",
         where: "deleted_at IS NULL"
+      t.index [:last_name],
+        name: "index_deleted_profiles_on_last_name",
+        where: "deleted_at IS NOT NULL"
     end
 
     refute_problems
@@ -28,7 +31,7 @@ class ActiveRecordDoctor::Detectors::UnindexedDeletedAtTest < Minitest::Test
     end
 
     assert_problems(<<~OUTPUT)
-      consider adding `WHERE deleted_at IS NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
+      consider adding `WHERE deleted_at IS NULL` or `WHERE deleted_at IS NOT NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
     OUTPUT
   end
 
@@ -42,6 +45,9 @@ class ActiveRecordDoctor::Detectors::UnindexedDeletedAtTest < Minitest::Test
       t.index [:first_name, :last_name],
         name: "index_profiles_on_first_name_and_last_name",
         where: "discarded_at IS NULL"
+      t.index [:last_name],
+        name: "index_discarded_profiles_on_last_name",
+        where: "discarded_at IS NOT NULL"
     end
 
     refute_problems
@@ -59,7 +65,7 @@ class ActiveRecordDoctor::Detectors::UnindexedDeletedAtTest < Minitest::Test
     end
 
     assert_problems(<<~OUTPUT)
-      consider adding `WHERE discarded_at IS NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
+      consider adding `WHERE discarded_at IS NULL` or `WHERE discarded_at IS NOT NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
     OUTPUT
   end
 
@@ -165,7 +171,7 @@ class ActiveRecordDoctor::Detectors::UnindexedDeletedAtTest < Minitest::Test
     CONFIG
 
     assert_problems(<<~OUTPUT)
-      consider adding `WHERE obliverated_at IS NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
+      consider adding `WHERE obliverated_at IS NULL` or `WHERE obliverated_at IS NOT NULL` to index_profiles_on_first_name_and_last_name - a partial index can speed lookups of soft-deletable models
     OUTPUT
   end
 end


### PR DESCRIPTION
The user will choose to add index to quickly get deleted items by some criteria: `add_index :users, :email, where: "deleted_at IS NOT NULL"`. 
We should accept this, because otherwise `WHERE deleted_at IS NOT NULL AND deleted_at IS NULL` does not make sense.