### PR TITLE
Ignore created_on/updated_on for missing_presence_validation

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -37,7 +37,7 @@ module ActiveRecordDoctor
       end
 
       def validator_needed?(model, column)
-        ![model.primary_key, "created_at", "updated_at"].include?(column.name) &&
+        ![model.primary_key, "created_at", "updated_at", "created_on", "updated_on"].include?(column.name) &&
           (!column.null || not_null_check_constraint_exists?(model.table_name, column))
       end
 

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -105,9 +105,15 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
 
   def test_timestamps_are_not_reported
     create_table(:users) do |t|
+      # Create created_at/updated_at timestamps.
       t.timestamps null: false
+
+      # Rails also supports created_on/updated_on. We used datetime, which is
+      # what the timestamps method users under the hood, to avoid default value
+      # errors in some MySQL versions when using t.timestamp.
+      t.datetime :created_on, null: false
+      t.datetime :updated_on, null: false
     end.create_model do
-      validates :name, presence: true
     end
 
     refute_problems


### PR DESCRIPTION
Rails also sets automatically `created_on/updated_on` columns when `created_at/updated_at` are missing. https://github.com/rails/rails/blob/be400c3ca2b86111766d840979478fc026679368/activerecord/lib/active_record/timestamp.rb#L82-L88