### PR TITLE
Ignore non-integer and non-uuid primary keys for short_primary_key_type

### DIFF
--- a/lib/active_record_doctor/detectors/short_primary_key_type.rb
+++ b/lib/active_record_doctor/detectors/short_primary_key_type.rb
@@ -23,7 +23,7 @@ module ActiveRecordDoctor
         each_table(except: config(:ignore_tables)) do |table|
           column = primary_key(table)
           next if column.nil?
-          next if bigint?(column) || uuid?(column)
+          next if !integer?(column) || bigint?(column)
 
           problem!(table: table, column: column.name)
         end
@@ -37,8 +37,8 @@ module ActiveRecordDoctor
         end
       end
 
-      def uuid?(column)
-        column.sql_type == "uuid"
+      def integer?(column)
+        column.type == :integer
       end
     end
   end

--- a/test/active_record_doctor/detectors/short_primary_key_type_test.rb
+++ b/test/active_record_doctor/detectors/short_primary_key_type_test.rb
@@ -25,6 +25,11 @@ class ActiveRecordDoctor::Detectors::ShortPrimaryKeyTypeTest < Minitest::Test
     OUTPUT
   end
 
+  def test_non_integer_and_non_uuid_primary_key_is_not_reported
+    create_table(:companies, id: :string, primary_key: :uuid)
+    refute_problems
+  end
+
   def test_long_integer_primary_key_is_not_reported
     create_table(:companies, id: :bigint)
     refute_problems


### PR DESCRIPTION
It is possible the user uses other types for primary keys, for example string `username` for `users` table, or client side generated uuid-like strings for some other tables, or external ids (like `stripe_id` string) for `stripe_users` table, etc. 