### PR TITLE
Detect missing unique lowercase indexes for case insensitive unique validations

### DIFF
--- a/lib/active_record_doctor.rb
+++ b/lib/active_record_doctor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record_doctor/railtie" if defined?(Rails) && defined?(Rails::Railtie)
+require "active_record_doctor/utils"
 require "active_record_doctor/logger"
 require "active_record_doctor/logger/dummy"
 require "active_record_doctor/logger/hierarchical"

--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -139,7 +139,7 @@ module ActiveRecordDoctor
         # ActiveRecord 6.1+
         if connection.respond_to?(:supports_check_constraints?) && connection.supports_check_constraints?
           connection.check_constraints(table_name).select(&:validated?).map(&:expression)
-        elsif postgresql?
+        elsif Utils.postgresql?(connection)
           definitions =
             connection.select_values(<<-SQL)
               SELECT pg_get_constraintdef(oid, true)
@@ -162,10 +162,6 @@ module ActiveRecordDoctor
 
       def underscored_name
         self.class.underscored_name
-      end
-
-      def postgresql?
-        ["PostgreSQL", "PostGIS"].include?(connection.adapter_name)
       end
 
       def each_model(except: [], abstract: nil, existing_tables_only: false)

--- a/lib/active_record_doctor/utils.rb
+++ b/lib/active_record_doctor/utils.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveRecordDoctor
+  module Utils # :nodoc:
+    class << self
+      def postgresql?(connection = ActiveRecord::Base.connection)
+        ["PostgreSQL", "PostGIS"].include?(connection.adapter_name)
+      end
+
+      def mysql?(connection = ActiveRecord::Base.connection)
+        connection.adapter_name == "Mysql2"
+      end
+
+      def expression_indexes_unsupported?(connection = ActiveRecord::Base.connection)
+        (ActiveRecord::VERSION::STRING < "5.0") ||
+          # Active Record < 6 is unable to correctly parse expression indexes for MySQL.
+          (mysql?(connection) && ActiveRecord::VERSION::STRING < "6.0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Case insensitivity in uniqueness validations was skipped in this gem, but this is a very popular problem. 
I remember I was trapped by this at least once. And there is even [a related article from Richard Scheeman](https://schneems.com/2017/07/18/how-i-reduced-my-db-server-load-by-80/) with his investigation of the performance problems on production with his findings.   

It adds some ugly columns parsing, but I think we can deal with it.