### PR TITLE
Check column name in length validators

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_length_validation.rb
+++ b/lib/active_record_doctor/detectors/incorrect_length_validation.rb
@@ -38,7 +38,7 @@ module ActiveRecordDoctor
             next if config(:ignore_attributes).include?("#{model.name}.#{column.name}")
             next if ![:string, :text].include?(column.type)
 
-            model_maximum = maximum_allowed_by_validations(model)
+            model_maximum = maximum_allowed_by_validations(model, column.name.to_sym)
             next if model_maximum == column.limit
 
             problem!(
@@ -52,9 +52,11 @@ module ActiveRecordDoctor
         end
       end
 
-      def maximum_allowed_by_validations(model)
+      def maximum_allowed_by_validations(model, column)
         length_validator = model.validators.find do |validator|
-          validator.kind == :length && validator.options.include?(:maximum)
+          validator.kind == :length &&
+            validator.options.include?(:maximum) &&
+            validator.attributes.include?(column)
         end
         length_validator ? length_validator.options[:maximum] : nil
       end

--- a/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
@@ -4,8 +4,10 @@ class ActiveRecordDoctor::Detectors::IncorrectLengthValidationTest < Minitest::T
   def test_validation_and_limit_equal_is_ok
     create_table(:users) do |t|
       t.string :email, limit: 64
+      t.string :name, limit: 32
     end.create_model do
       validates :email, length: { maximum: 64 }
+      validates :name, length: { maximum: 32 }
     end
 
     refute_problems


### PR DESCRIPTION
While checking each column for length validations in the model, the column name is not considered. By not doing this, the first model validation will be the one setting the conditions  for all columns in the schema.