### PR TITLE
Correctly check column types when FK refers to non-PK column

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,3 +129,6 @@ Naming/MethodParameterName:
   AllowedNames:
     - as
     - io
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false

--- a/lib/active_record_doctor/detectors/mismatched_foreign_key_type.rb
+++ b/lib/active_record_doctor/detectors/mismatched_foreign_key_type.rb
@@ -18,9 +18,9 @@ module ActiveRecordDoctor
 
       private
 
-      def message(table:, column:)
+      def message(from_table:, from_column:, from_type:, to_table:, to_column:, to_type:)
         # rubocop:disable Layout/LineLength
-        "#{table}.#{column} references a column of different type - foreign keys should be of the same type as the referenced column"
+        "#{from_table}.#{from_column} is a foreign key of type #{from_type} and references #{to_table}.#{to_column} of type #{to_type} - foreign keys should be of the same type as the referenced column"
         # rubocop:enable Layout/LineLength
       end
 
@@ -32,12 +32,18 @@ module ActiveRecordDoctor
             next if config(:ignore_columns).include?("#{table}.#{from_column.name}")
 
             to_table = foreign_key.to_table
-            primary_key_name = foreign_key.primary_key
-            primary_key = column(to_table, primary_key_name)
+            to_column = column(to_table, foreign_key.primary_key)
 
-            next if from_column.sql_type == primary_key.sql_type
+            next if from_column.sql_type == to_column.sql_type
 
-            problem!(table: table, column: from_column.name)
+            problem!(
+              from_table: table,
+              from_column: from_column.name,
+              from_type: from_column.sql_type,
+              to_table: to_table,
+              to_column: to_column.name,
+              to_type: to_column.sql_type
+            )
           end
         end
       end

--- a/lib/active_record_doctor/detectors/mismatched_foreign_key_type.rb
+++ b/lib/active_record_doctor/detectors/mismatched_foreign_key_type.rb
@@ -32,7 +32,8 @@ module ActiveRecordDoctor
             next if config(:ignore_columns).include?("#{table}.#{from_column.name}")
 
             to_table = foreign_key.to_table
-            primary_key = primary_key(to_table)
+            primary_key_name = foreign_key.primary_key
+            primary_key = column(to_table, primary_key_name)
 
             next if from_column.sql_type == primary_key.sql_type
 

--- a/test/active_record_doctor/detectors/mismatched_foreign_key_type_test.rb
+++ b/test/active_record_doctor/detectors/mismatched_foreign_key_type_test.rb
@@ -15,6 +15,22 @@ class ActiveRecordDoctor::Detectors::MismatchedForeignKeyTypeTest < Minitest::Te
     OUTPUT
   end
 
+  def test_matched_foreign_key_with_non_primary_key_type_is_not_reported
+    # MySQL does not allow foreign keys to have different type than paired primary keys
+    return if mysql?
+
+    create_table(:companies, id: :bigint) do |t|
+      t.integer :entity_id
+      t.index [:entity_id], unique: true
+    end
+    create_table(:users) do |t|
+      t.references :entity, foreign_key: false, type: :integer, index: false
+      t.foreign_key :companies, column: :entity_id, primary_key: :entity_id
+    end
+
+    refute_problems
+  end
+
   def test_matched_foreign_key_type_is_not_reported
     create_table(:companies)
     create_table(:users) do |t|


### PR DESCRIPTION
Imagine you have two tables `companies` and `users` like the following
![image](https://user-images.githubusercontent.com/4459657/209388849-4299179c-a0d7-40a8-81e2-dd799ebcdc00.png)

Let's say that, for some reason, you need to create an FK on the `entity_id` column connecting both tables
![image](https://user-images.githubusercontent.com/4459657/209389463-3323b80b-cb59-473e-85ba-792e635eba4f.png)

Considering the column in the referenced table is unique it works quite fine in terms of Database but, if you run AR Doctor on a project with these tables the result will be:

`users.entity_id references a column of a different type - foreign keys should be of the same type as the referenced column`

That's because it currently compares the FK column with the PK of the referenced table and not the column the FK refers to.

This PR intends to fix it by fetching the column based on the FK referenced column instead.