### PR TITLE
Expect unique indexes on `has_and_belongs_to_many` associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,9 @@ Supported configuration options:
 
 ### Detecting Uniqueness Validations not Backed by an Index
 
-Model-level uniqueness validations and `has_one` associations should be backed
-by a database index in order to be robust. Otherwise you risk inserting
-duplicate values under a heavy load.
+Model-level uniqueness validations, `has_one` and `has_and_belongs_to_many`
+associations should be backed by a database index in order to be robust.
+Otherwise you risk inserting duplicate values under a heavy load.
 
 In order to detect such validations run:
 
@@ -396,6 +396,8 @@ Supported configuration options:
 - `ignore_models` - models whose uniqueness validators should not be checked.
 - `ignore_columns` - specific validators, written as Model(column1, ...), that
   should not be checked.
+- `ignore_join_tables` - join tables that should not be checked for existence
+  of unique indexes.
 
 ### Detecting Missing Non-`NULL` Constraints
 

--- a/lib/active_record_doctor/config/default.rb
+++ b/lib/active_record_doctor/config/default.rb
@@ -52,7 +52,8 @@ ActiveRecordDoctor.configure do
   detector :missing_unique_indexes,
     enabled: true,
     ignore_models: [],
-    ignore_columns: []
+    ignore_columns: [],
+    ignore_join_tables: []
 
   detector :short_primary_key_type,
     enabled: true,

--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -157,7 +157,7 @@ module ActiveRecordDoctor
       end
 
       def models
-        ActiveRecord::Base.descendants
+        ActiveRecord::Base.descendants.sort_by(&:name)
       end
 
       def underscored_name


### PR DESCRIPTION
This commit enhances the missing_unique_index detector by making it aware of `has_and_belongs_to_many` associations, in addition to `has_one` associations and uniqueness validations.

This case is very often overlooked and leads to duplicates in the database or/and some unnecessary code to deal with duplicates.
I tried to imagine the case when duplicates would be useful, but was unable to do so. Instead I was able to google a couple of posts with people ranting ([example1](http://spoolz.com/2014/05/20/rails-habtm-with-unique-scope-and-select-columns/), [example2](https://www.semicolonandsons.com/code_diary/databases/has-and-belongs-to-many-tables-often-need-unique-indexes)) and suggesting to add unique indexes on it.  