### PR TITLE
Enhance handling of polymorphic foreign key-like columns in `UnindexedForeignKeys`

### DIFF
--- a/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
+++ b/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
@@ -10,16 +10,16 @@ module ActiveRecordDoctor
       migration_descriptions = read_migration_descriptions(path)
       now = Time.now
 
-      migration_descriptions.each_with_index do |(table, columns), index|
+      migration_descriptions.each_with_index do |(table, indexes), index|
         timestamp = (now + index).strftime("%Y%m%d%H%M%S")
         file_name = "db/migrate/#{timestamp}_index_foreign_keys_in_#{table}.rb"
-        create_file(file_name, content(table, columns).tap { |x| puts x })
+        create_file(file_name, content(table, indexes).tap { |x| puts x })
       end
     end
 
     private
 
-    INPUT_LINE = /^add an index on (\w+)\.(\w+) - .*$/.freeze
+    INPUT_LINE = /^add an index on (\w+)\((.+)\) - .*$/.freeze
     private_constant :INPUT_LINE
 
     def read_migration_descriptions(path)
@@ -34,41 +34,41 @@ module ActiveRecordDoctor
         end
 
         table = match[1]
-        column = match[2]
+        columns = match[2].split(",").map(&:strip)
 
-        tables_to_columns[table] << column
+        tables_to_columns[table] << columns
       end
 
       tables_to_columns
     end
 
-    def content(table, columns)
+    def content(table, indexes)
       # In order to properly indent the resulting code, we must disable the
       # rubocop rule below.
 
       <<MIGRATION
 class IndexForeignKeysIn#{table.camelize} < ActiveRecord::Migration#{migration_version}
   def change
-#{add_indexes(table, columns)}
+#{add_indexes(table, indexes)}
   end
 end
 MIGRATION
     end
 
-    def add_indexes(table, columns)
-      columns.map do |column|
-        add_index(table, column)
+    def add_indexes(table, indexes)
+      indexes.map do |columns|
+        add_index(table, columns)
       end.join("\n")
     end
 
-    def add_index(table, column)
+    def add_index(table, columns)
       connection = ActiveRecord::Base.connection
 
-      index_name = connection.index_name(table, column)
+      index_name = connection.index_name(table, columns)
       if index_name.size > connection.index_name_length
-        "    add_index :#{table}, :#{column}, name: '#{index_name.first(connection.index_name_length)}'"
+        "    add_index :#{table}, #{columns.inspect}, name: '#{index_name.first(connection.index_name_length)}'"
       else
-        "    add_index :#{table}, :#{column}"
+        "    add_index :#{table}, #{columns.inspect}"
       end
     end
 


### PR DESCRIPTION
Accept polymorphic foreign key-like columns which are a prefix of a larger index. Previously, only exact match on index columns was made.