### PR TITLE
Ignore `:through` associations in `IncorrectDependentOption` detector

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
+++ b/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
@@ -48,6 +48,8 @@ module ActiveRecordDoctor
                          model.reflect_on_all_associations(:has_one) +
                          model.reflect_on_all_associations(:belongs_to)
 
+          associations = associations.reject { |reflection| through_reflection?(reflection) }
+
           associations.each do |association|
             next if config(:ignore_associations).include?("#{model.name}.#{association.name}")
 
@@ -76,6 +78,11 @@ module ActiveRecordDoctor
             end
           end
         end
+      end
+
+      def through_reflection?(reflection)
+        # For Active Record >= 5, we can use `.through_reflection?`.
+        reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
       end
 
       def models_having(as:)

--- a/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
@@ -326,6 +326,20 @@ class ActiveRecordDoctor::Detectors::IncorrectDependentOptionTest < Minitest::Te
     refute_problems
   end
 
+  def test_ignores_through_associations
+    create_table(:users) do
+    end.define_model do
+      has_many :posts
+      has_many :comments, through: :posts
+    end
+
+    create_table(:posts) do |t|
+      t.references :users
+    end.define_model
+
+    refute_problems
+  end
+
   def test_config_ignore_models
     create_table(:companies) do
     end.define_model do


### PR DESCRIPTION
Fixes #123.