### PR TITLE
Detect extraneous indexes on PostgreSQL materialized views

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -281,6 +281,20 @@ module ActiveRecordDoctor
         end
       end
 
+      def each_data_source(except: [])
+        log("Iterating over data sources") do
+          connection.data_sources.each do |data_source|
+            if except.include?(data_source)
+              log("#{data_source} - ignored via the configuration; skipping")
+            else
+              log(data_source) do
+                yield(data_source)
+              end
+            end
+          end
+        end
+      end
+
       def each_association(model, except: [], type: [:has_many, :has_one, :belongs_to], has_scope: nil, through: nil)
         type = Array(type)
 

--- a/lib/active_record_doctor/detectors/extraneous_indexes.rb
+++ b/lib/active_record_doctor/detectors/extraneous_indexes.rb
@@ -34,7 +34,7 @@ module ActiveRecordDoctor
 
       def subindexes_of_multi_column_indexes
         log(__method__) do
-          each_table(except: config(:ignore_tables)) do |table|
+          each_data_source(except: config(:ignore_tables)) do |table|
             each_index(table, except: config(:ignore_indexes), multicolumn_only: true) do |index, indexes|
               replacement_indexes = indexes.select do |other_index|
                 index != other_index && replaceable_with?(index, other_index)


### PR DESCRIPTION
Just found an extra index on the materialized view in my codebase.

Theoretically, other detectors, like `UnindexedForeignKeys` and `UnindexedDeletedAt` can be easily extended to handle materialized views too, but I think the case with extra indexes is the most popular.