### PR TITLE
Support PostgreSQL `INCLUDE` indexes in `ExtraneousIndexes` checker

### DIFF
--- a/lib/active_record_doctor/detectors/extraneous_indexes.rb
+++ b/lib/active_record_doctor/detectors/extraneous_indexes.rb
@@ -81,11 +81,12 @@ module ActiveRecordDoctor
 
         case [index1.unique, index2.unique]
         when [true, true]
-          (index2_columns - index1_columns).empty?
+          contains_all?(index1_columns, index2_columns)
         when [true, false]
           false
         else
-          prefix?(index1_columns, index2_columns)
+          prefix?(index1_columns, index2_columns) &&
+            contains_all?(index2_columns + includes(index2), includes(index1))
         end
       end
 
@@ -95,6 +96,14 @@ module ActiveRecordDoctor
 
       def prefix?(lhs, rhs)
         lhs.count <= rhs.count && rhs[0...lhs.count] == lhs
+      end
+
+      def contains_all?(array1, array2)
+        (array2 - array1).empty?
+      end
+
+      def includes(index)
+        index.respond_to?(:include) ? Array(index.include) : []
       end
     end
   end


### PR DESCRIPTION
Rails 7.1 will have support for PostgreSQL `INCLUDE` indexes - https://github.com/rails/rails/pull/44803. If you are ok with this PR changes, we can wait when the new rails version is released or can merge earlier, since some people are running on some sort of rails head and will already benefit from this.

This gem's CI is not testing against rails head, so the newly added tests are skipped currently. 