### PR TITLE
Fix `extraneous_indexes` for expression indexes

### DIFF
--- a/lib/active_record_doctor/detectors/extraneous_indexes.rb
+++ b/lib/active_record_doctor/detectors/extraneous_indexes.rb
@@ -73,13 +73,16 @@ module ActiveRecordDoctor
         return false if index1.where != index2.where
         return false if opclasses(index1) != opclasses(index2)
 
+        index1_columns = Array(index1.columns)
+        index2_columns = Array(index2.columns)
+
         case [index1.unique, index2.unique]
         when [true, true]
-          (index2.columns - index1.columns).empty?
+          (index2_columns - index1_columns).empty?
         when [true, false]
           false
         else
-          prefix?(index1, index2)
+          prefix?(index1_columns, index2_columns)
         end
       end
 
@@ -88,8 +91,7 @@ module ActiveRecordDoctor
       end
 
       def prefix?(lhs, rhs)
-        lhs.columns.count <= rhs.columns.count &&
-          rhs.columns[0...lhs.columns.count] == lhs.columns
+        lhs.count <= rhs.count && rhs[0...lhs.count] == lhs
       end
     end
   end

--- a/test/active_record_doctor/detectors/extraneous_indexes_test.rb
+++ b/test/active_record_doctor/detectors/extraneous_indexes_test.rb
@@ -95,6 +95,32 @@ remove index_users_on_last_name_and_first_name - can be replaced by index_users_
 OUTPUT
   end
 
+  def test_expression_index_not_covered_by_multicolumn_index
+    skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
+
+    create_table(:users) do |t|
+      t.string :first_name
+      t.string :email
+      t.index "(lower(email))"
+      t.index [:first_name, :email]
+    end
+
+    refute_problems
+  end
+
+  def test_unique_expression_index_not_covered_by_unique_multicolumn_index
+    skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
+
+    create_table(:users) do |t|
+      t.string :first_name
+      t.string :email
+      t.index "(lower(email))", unique: true
+      t.index [:first_name, :email], unique: true
+    end
+
+    refute_problems
+  end
+
   def test_not_covered_by_different_index_type
     create_table(:users) do |t|
       t.string :first_name


### PR DESCRIPTION
ActiveRecord returns `columns` for expression indexes as a string and `columns.count` raises an argument error, since is called on a string.