### PR TITLE
Fix loading `ActiveRecordDoctor::Rake::Task` for non rails projects

### DIFF
--- a/lib/active_record_doctor.rb
+++ b/lib/active_record_doctor.rb
@@ -26,6 +26,7 @@ require "active_record_doctor/runner"
 require "active_record_doctor/version"
 require "active_record_doctor/config"
 require "active_record_doctor/config/loader"
+require "active_record_doctor/rake/task"
 
 module ActiveRecordDoctor # :nodoc:
 end


### PR DESCRIPTION
Fixes https://github.com/gregnavis/active_record_doctor/issues/134.