### PR TITLE
Fix ignoring columns from `has_one` association for `missing_unique_indexes`

### DIFF
--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -601,6 +601,26 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     refute_problems
   end
 
+  def test_config_ignore_columns_from_has_one
+    Context.create_table(:users)
+      .define_model do
+        has_one :account, class_name: "Context::Account"
+      end
+
+    Context.create_table(:accounts) do |t|
+      t.integer :user_id
+    end.define_model
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :missing_unique_indexes,
+          ignore_columns: ["Context::Account(user_id)"]
+      end
+    CONFIG
+
+    refute_problems
+  end
+
   class DummyValidator < ActiveModel::Validator
     def validate(record)
     end


### PR DESCRIPTION
```ruby
class User
  has_one :account
end

class Account
end
```

To disable `missing_unique_indexes` for checking unique index on `accounts.user_id`, we currently should add `ignore_columns: ["User(user_id)"]` to the config, which does not make sense. This PR fixes that so we should write as `ignore_columns: ["Account(user_id)"]`. 