### PR TITLE
Fix `missing_non_null_constraint` when there are no STI children for STI-like parent

### DIFF
--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -36,6 +36,7 @@ module ActiveRecordDoctor
             next if ignored?("#{table}.#{column.name}", config(:ignore_columns))
             next if !column.null
             next if !concrete_models.all? { |model| non_null_needed?(model, column) }
+            next if sti_column?(models, column.name)
             next if not_null_check_constraint_exists?(table, column)
 
             problem!(column: column.name, table: table)
@@ -69,6 +70,10 @@ module ActiveRecordDoctor
             !validator.options[:if] &&
             !validator.options[:unless]
         end
+      end
+
+      def sti_column?(models, column_name)
+        models.any? { |model| model.inheritance_column == column_name }
       end
     end
   end

--- a/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
+++ b/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
@@ -187,6 +187,24 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
+  def test_sti_column_is_ignored
+    Context.create_table(:users) do |t|
+      t.string :type
+    end.define_model
+
+    refute_problems
+  end
+
+  def test_custom_sti_column_is_ignored
+    Context.create_table(:users) do |t|
+      t.string :custom_type
+    end.define_model do
+      self.inheritance_column = :custom_type
+    end
+
+    refute_problems
+  end
+
   def test_not_null_check_constraint
     skip unless postgresql?
 


### PR DESCRIPTION
When the STI-like parent model has no children, all the `next` branches in the `detect` method pass (specifically `next if !concrete_models.all? { |model| non_null_needed?(model, column) }`) and `MissingNonNullConstraint` erroneously adds offenses for the column. See a test case for the example.