### PR TITLE
Include table name in the message for `extraneous_indexes`

### DIFF
--- a/lib/active_record_doctor/detectors/extraneous_indexes.rb
+++ b/lib/active_record_doctor/detectors/extraneous_indexes.rb
@@ -19,12 +19,12 @@ module ActiveRecordDoctor
 
       private
 
-      def message(extraneous_index:, replacement_indexes:)
+      def message(table:, extraneous_index:, replacement_indexes:)
         if replacement_indexes.nil?
-          "remove #{extraneous_index} - coincides with the primary key on the table"
+          "remove #{extraneous_index} from #{table} - coincides with the primary key on the table"
         else
           # rubocop:disable Layout/LineLength
-          "remove #{extraneous_index} - queries should be able to use the following #{'index'.pluralize(replacement_indexes.count)} instead: #{replacement_indexes.join(' or ')}"
+          "remove the index #{extraneous_index} from the table #{table} - queries should be able to use the following #{'index'.pluralize(replacement_indexes.count)} instead: #{replacement_indexes.join(' or ')}"
           # rubocop:enable Layout/LineLength
         end
       end
@@ -48,6 +48,7 @@ module ActiveRecordDoctor
               end
 
               problem!(
+                table: table,
                 extraneous_index: index.name,
                 replacement_indexes: replacement_indexes.map(&:name).sort
               )
@@ -62,7 +63,7 @@ module ActiveRecordDoctor
             each_index(table, except: config(:ignore_indexes), multicolumn_only: true) do |index|
               primary_key = connection.primary_key(table)
               if index.columns == [primary_key] && index.where.nil?
-                problem!(extraneous_index: index.name, replacement_indexes: nil)
+                problem!(table: table, extraneous_index: index.name, replacement_indexes: nil)
               end
             end
           end

--- a/test/active_record_doctor/detectors/extraneous_indexes_test.rb
+++ b/test/active_record_doctor/detectors/extraneous_indexes_test.rb
@@ -7,7 +7,7 @@ class ActiveRecordDoctor::Detectors::ExtraneousIndexesTest < Minitest::Test
     end
 
     assert_problems(<<OUTPUT)
-remove index_users_on_id - coincides with the primary key on the table
+remove index_users_on_id from users - coincides with the primary key on the table
 OUTPUT
   end
 
@@ -28,7 +28,7 @@ OUTPUT
     end
 
     assert_problems(<<OUTPUT)
-remove index_profiles_on_user_id - coincides with the primary key on the table
+remove index_profiles_on_user_id from profiles - coincides with the primary key on the table
 OUTPUT
   end
 
@@ -42,7 +42,7 @@ OUTPUT
     ActiveRecord::Base.connection.add_index :users, :email, name: "index_users_on_email"
 
     assert_problems(<<OUTPUT)
-remove index_users_on_email - queries should be able to use the following index instead: unique_index_on_users_email
+remove the index index_users_on_email from the table users - queries should be able to use the following index instead: unique_index_on_users_email
 OUTPUT
   end
 
@@ -59,7 +59,7 @@ OUTPUT
     end
 
     assert_problems(<<OUTPUT)
-remove index_users_on_last_name - queries should be able to use the following indices instead: index_users_on_last_name_and_first_name_and_email or unique_index_on_users_last_name_and_first_name
+remove the index index_users_on_last_name from the table users - queries should be able to use the following indices instead: index_users_on_last_name_and_first_name_and_email or unique_index_on_users_last_name_and_first_name
 OUTPUT
   end
 
@@ -78,7 +78,7 @@ OUTPUT
     ActiveRecord::Base.connection.add_index :users, [:last_name, :first_name]
 
     assert_problems(<<OUTPUT)
-remove index_users_on_last_name_and_first_name - queries should be able to use the following indices instead: index_users_on_last_name_and_first_name_and_email or unique_index_on_users_last_name_and_first_name
+remove the index index_users_on_last_name_and_first_name from the table users - queries should be able to use the following indices instead: index_users_on_last_name_and_first_name_and_email or unique_index_on_users_last_name_and_first_name
 OUTPUT
   end
 
@@ -91,7 +91,7 @@ OUTPUT
     end
 
     assert_problems(<<OUTPUT)
-remove index_users_on_last_name_and_first_name - queries should be able to use the following index instead: index_users_on_first_name
+remove the index index_users_on_last_name_and_first_name from the table users - queries should be able to use the following index instead: index_users_on_first_name
 OUTPUT
   end
 
@@ -159,7 +159,7 @@ OUTPUT
       connection.add_index(:user_initials, :last_name)
 
       assert_problems(<<OUTPUT)
-remove index_user_initials_on_last_name - queries should be able to use the following index instead: index_user_initials_on_last_name_and_first_name
+remove the index index_user_initials_on_last_name from the table user_initials - queries should be able to use the following index instead: index_user_initials_on_last_name_and_first_name
 OUTPUT
     ensure
       connection.execute("DROP MATERIALIZED VIEW user_initials")


### PR DESCRIPTION
I recently tested this gem on a project which has quite a few matviews in the database and a foreign wrapper for MySQL, but still is using `schema.rb` without dumped them there (don't ask why). And when `extraneous_indexes` reported extra indexes, it hasn't mentioned where these indexes are defined, so it was quite a challenge to find it through `psql`. This PR simplifies such debugging for future users. 