### PR TITLE
Test against `activerecord` 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.5
+          ruby-version: 3.0
           bundler-cache: true
       - run: bundle exec rake rubocop
 
@@ -58,79 +58,79 @@ jobs:
         #
         #   https://github.com/ruby/setup-ruby/issues/150
         include:
-          - ruby-version: 2.4.10
-            gemfile: gemfiles/Gemfile.activerecord-4.2.x
+          - ruby-version: 2.4
+            gemfile: Gemfile.activerecord-4.2.x
             bundler: 1.17.3
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-4.2.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-4.2.x
             bundler: 1.17.3
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-4.2.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-4.2.x
             bundler: 1.17.3
 
-          - ruby-version: 2.4.10
-            gemfile: gemfiles/Gemfile.activerecord-5.0.x
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-5.0.x
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-5.0.x
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-5.0.x
+          - ruby-version: 2.4
+            gemfile: Gemfile.activerecord-5.0.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-5.0.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-5.0.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-5.0.x
 
-          - ruby-version: 2.4.10
-            gemfile: gemfiles/Gemfile.activerecord-5.1.x
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-5.1.x
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-5.1.x
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-5.1.x
+          - ruby-version: 2.4
+            gemfile: Gemfile.activerecord-5.1.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-5.1.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-5.1.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-5.1.x
 
-          - ruby-version: 2.4.10
-            gemfile: gemfiles/Gemfile.activerecord-5.2.x
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-5.2.x
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-5.2.x
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-5.2.x
+          - ruby-version: 2.4
+            gemfile: Gemfile.activerecord-5.2.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-5.2.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-5.2.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-5.2.x
 
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-6.0.x
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-6.0.x
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-6.0.x
-          - ruby-version: 3.0.5
-            gemfile: gemfiles/Gemfile.activerecord-6.0.x
-          - ruby-version: 3.1.3
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 3.2.0
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-6.0.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-6.0.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-6.0.x
+          - ruby-version: 3.0
+            gemfile: Gemfile.activerecord-6.0.x
+          - ruby-version: 3.1
+            gemfile: Gemfile.activerecord-6.0.x
+          - ruby-version: 3.2
+            gemfile: Gemfile.activerecord-6.0.x
 
-          - ruby-version: 2.5.9
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 2.6.10
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 3.0.5
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 3.1.3
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
-          - ruby-version: 3.2.0
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
+          - ruby-version: 2.5
+            gemfile: Gemfile.activerecord-6.1.x
+          - ruby-version: 2.6
+            gemfile: Gemfile.activerecord-6.1.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-6.1.x
+          - ruby-version: 3.0
+            gemfile: Gemfile.activerecord-6.1.x
+          - ruby-version: 3.1
+            gemfile: Gemfile.activerecord-6.1.x
+          - ruby-version: 3.2
+            gemfile: Gemfile.activerecord-6.1.x
 
-          - ruby-version: 2.7.7
-            gemfile: gemfiles/Gemfile.activerecord-7.0.x
-          - ruby-version: 3.0.5
-            gemfile: gemfiles/Gemfile.activerecord-7.0.x
-          - ruby-version: 3.1.3
-            gemfile: gemfiles/Gemfile.activerecord-7.0.x
-          - ruby-version: 3.2.0
-            gemfile: gemfiles/Gemfile.activerecord-6.1.x
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-7.0.x
+          - ruby-version: 3.0
+            gemfile: Gemfile.activerecord-7.0.x
+          - ruby-version: 3.1
+            gemfile: Gemfile.activerecord-7.0.x
+          - ruby-version: 3.2
+            gemfile: Gemfile.activerecord-7.0.x
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,15 @@ jobs:
             gemfile: Gemfile.activerecord-7.0.x
           - ruby-version: 3.2
             gemfile: Gemfile.activerecord-7.0.x
+
+          - ruby-version: 2.7
+            gemfile: Gemfile.activerecord-7.1.x
+          - ruby-version: 3.0
+            gemfile: Gemfile.activerecord-7.1.x
+          - ruby-version: 3.1
+            gemfile: Gemfile.activerecord-7.1.x
+          - ruby-version: 3.2
+            gemfile: Gemfile.activerecord-7.1.x
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}
     steps:

--- a/gemfiles/Gemfile.activerecord-7.1.x
+++ b/gemfiles/Gemfile.activerecord-7.1.x
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+gemspec path: File.join(File.dirname(__FILE__), "..")
+
+gem "activerecord", "~> 7.1.0"
+
+# Older versions result in lots of warnings in Ruby 2.7.
+gem "pg", "~> 1.4.5"
+gem "mysql2", "~> 0.5.3"


### PR DESCRIPTION
I made 2 changes in this PR:
1. Updated Actions config to exclude specific ruby versions (this way it will run on the latest version each time and no need to update these versions in the future); fixed some incorrect gemfiles specifications
2. Configured to test against activerecord 7.1

I would also suggest to test against rails' `HEAD`. Some people run it in production.