### PR TITLE
Fix `MissingNonNullConstraint` to work with `ActiveRecord.belongs_to_required_validates_foreign_key`

### DIFF
--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -66,9 +66,19 @@ module ActiveRecordDoctor
         model.validators.select do |validator|
           validator.is_a?(ActiveRecord::Validations::PresenceValidator) &&
             !validator.options[:allow_nil] &&
-            !validator.options[:if] &&
-            !validator.options[:unless]
+            (required_with_if?(validator) || !conditional_validator?(validator))
         end
+      end
+
+      def required_with_if?(validator)
+        ActiveRecord.version >= Gem::Version.new("7.1") &&
+          !ActiveRecord.belongs_to_required_validates_foreign_key &&
+          validator.options[:message] == :required &&
+          validator.options[:if].present?
+      end
+
+      def conditional_validator?(validator)
+        validator.options[:if] || validator.options[:unless]
       end
     end
   end

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -99,6 +99,13 @@ if ActiveRecord::VERSION::MAJOR >= 6
   SecondaryContext = TransientRecord.context_for SecondaryRecord
 end
 
+if ActiveRecord.version >= Gem::Version.new("7.1")
+  # See https://github.com/rails/rails/pull/46522 for details.
+  # When `false` (default in Rails 7.1) - validate presence only when the foreign key changed.
+  # When `true` - always validate the association presence.
+  ActiveRecord.belongs_to_required_validates_foreign_key = true
+end
+
 # Prepare the test class.
 class Minitest::Test
   def setup


### PR DESCRIPTION
Rails 7.1 introduced an optimization to required `belongs_to` association to not check for presence when foreign key's value hasn't changed (see https://github.com/rails/rails/pull/46522 for details).

In this PR I made `active_record_doctor` be aware of this configuration. We can assume, that if a validator has an `:if` condition **and** validation's message is `:required` **and** `ActiveRecord.belongs_to_required_validates_foreign_key == false`, then this condition was set with the rails itself (not a conditional set by the user). 