### PR TITLE
Fix `missing_unique_indexes` detector's `ignore_columns` config for `has_one` associations

### DIFF
--- a/lib/active_record_doctor/detectors/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/detectors/missing_unique_indexes.rb
@@ -93,7 +93,7 @@ module ActiveRecordDoctor
               else
                 [has_one.foreign_key.to_s]
               end
-            next if ignored?("#{model.name}(#{columns.join(',')})", ignore_columns)
+            next if ignored?("#{has_one.klass.name}(#{columns.join(',')})", ignore_columns)
 
             table_name = has_one.klass.table_name
             next if unique_index?(table_name, columns)

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -477,6 +477,25 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     refute_problems
   end
 
+  def test_config_ignore_columns_for_has_one
+    Context.create_table(:users).define_model do
+      has_one :account, class_name: "Context::Account"
+    end
+
+    Context.create_table(:accounts) do |t|
+      t.integer :user_id
+    end.define_model
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :missing_unique_indexes,
+          ignore_columns: ["Context::Account(user_id)"]
+      end
+    CONFIG
+
+    refute_problems
+  end
+
   class DummyValidator < ActiveModel::Validator
     def validate(record)
     end


### PR DESCRIPTION
Fixes #152.