### PR TITLE
Fix `missing_presence_validation` for custom attributes with defaults

### DIFF
--- a/lib/active_record_doctor/utils.rb
+++ b/lib/active_record_doctor/utils.rb
@@ -16,6 +16,10 @@ module ActiveRecordDoctor
           # Active Record is unable to correctly parse expression indexes for MySQL.
           (mysql?(connection) && ActiveRecord::VERSION::STRING < "7.1")
       end
+
+      def attributes_api_supported?
+        ActiveRecord::VERSION::STRING >= "5.0"
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #154.

This PR fixes `missing_presence_validation` not only for `enum`s (which is internally defined as an `attribute`), but for any `attribute` having a default.