### PR TITLE
Fix a false positive for `unindexed_foreign_keys` when having foreign key on a primary key column

### DIFF
--- a/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
@@ -30,6 +30,7 @@ module ActiveRecordDoctor
             next unless named_like_foreign_key?(column) || foreign_key?(table, column)
             next if indexed?(table, column)
             next if indexed_as_polymorphic?(table, column)
+            next if connection.primary_key(table) == column.name
 
             type_column_name = type_column_name(column)
 

--- a/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
+++ b/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
@@ -61,6 +61,14 @@ class ActiveRecordDoctor::Detectors::UnindexedForeignKeysTest < Minitest::Test
     refute_problems
   end
 
+  def test_foreign_key_is_a_primary_key_not_reported
+    Context.create_table(:parents)
+    Context.create_table(:children, primary_key: :parent_id)
+    ActiveRecord::Base.connection.add_foreign_key(:children, :parents)
+
+    refute_problems
+  end
+
   def test_config_ignore_tables
     skip("MySQL always indexes foreign keys") if mysql?
 


### PR DESCRIPTION
Fixes #156.