### PR TITLE
Fix a false positive for `unique_indexes` when `has_one` on a primary key column

### DIFF
--- a/lib/active_record_doctor/detectors/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/detectors/missing_unique_indexes.rb
@@ -97,6 +97,7 @@ module ActiveRecordDoctor
 
             table_name = has_one.klass.table_name
             next if unique_index?(table_name, columns)
+            next if Array(connection.primary_key(table_name)) == columns
 
             problem!(model: model, table: table_name, columns: columns, problem: :has_ones)
           end

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -426,6 +426,22 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     refute_problems
   end
 
+  def test_has_one_on_primary_key_column
+    Context
+      .create_table(:parents)
+      .define_model do
+        has_one :child
+      end
+
+    Context
+      .create_table(:children, primary_key: :parent_id)
+      .define_model do
+        belongs_to :parent
+      end
+
+    refute_problems
+  end
+
   def test_config_ignore_models
     Context.create_table(:users) do |t|
       t.string :email


### PR DESCRIPTION
https://github.com/gregnavis/active_record_doctor/pull/157#issuecomment-1824759221