### PR TITLE
Suggest using config file with `.rb` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ActiveRecordDoctor::Rake::Task.new do |task|
   task.deps = []
 
   # A path to your active_record_doctor configuration file.
-  task.config_path = ::Rails.root.join(".active_record_doctor")
+  task.config_path = ::Rails.root.join(".active_record_doctor.rb")
 
   # A Proc called right before running detectors that should ensure your Active
   # Record models are preloaded and a database connection is ready.
@@ -111,7 +111,7 @@ If you want to use the default configuration then you don't have to do anything.
 Just run `active_record_doctor` in your project directory.
 
 If you want to customize the tool you should create a file named
-`.active_record_doctor` in your project root directory with content like:
+`.active_record_doctor.rb` in your project root directory with content like:
 
 ```ruby
 ActiveRecordDoctor.configure do

--- a/lib/tasks/active_record_doctor.rake
+++ b/lib/tasks/active_record_doctor.rake
@@ -19,6 +19,8 @@ ActiveRecordDoctor::Rake::Task.new do |task|
   # This file is imported when active_record_doctor is being used as part of a
   # Rails app so it's the right place for all Rails-specific settings.
   task.deps = [:environment]
-  task.config_path = Rails.root.join(".active_record_doctor")
+
+  config_name = ".active_record_doctor"
+  task.config_path = Rails.root.join(config_name).existence || Rails.root.join("#{config_name}.rb").existence
   task.setup = -> { Rails.application.eager_load! }
 end


### PR DESCRIPTION
Fixes #159.

Backwards compatibility is preserved to also accept `.active_record_doctor` files by default (without extension), if present.