### PR TITLE
Change the default configuration file to .active_record_doctor.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ActiveRecordDoctor::Rake::Task.new do |task|
   task.deps = []
 
   # A path to your active_record_doctor configuration file.
-  task.config_path = ::Rails.root.join(".active_record_doctor")
+  task.config_path = ::Rails.root.join(".active_record_doctor.rb")
 
   # A Proc called right before running detectors that should ensure your Active
   # Record models are preloaded and a database connection is ready.
@@ -111,7 +111,7 @@ If you want to use the default configuration then you don't have to do anything.
 Just run `active_record_doctor` in your project directory.
 
 If you want to customize the tool you should create a file named
-`.active_record_doctor` in your project root directory with content like:
+`.active_record_doctor.rb` in your project root directory with content like:
 
 ```ruby
 ActiveRecordDoctor.configure do

--- a/lib/active_record_doctor/rake/task.rb
+++ b/lib/active_record_doctor/rake/task.rb
@@ -69,7 +69,24 @@ module ActiveRecordDoctor
 
       def config
         @config ||= begin
-          path = config_path && File.exist?(config_path) ? config_path : nil
+          path = nil
+
+          if config_path
+            if File.exist?(config_path)
+              path = config_path
+            elsif config_path.to_s.end_with?(".rb")
+              config_path_without_extension = config_path.to_s.gsub(/\.rb\z/, "")
+              if File.exist?(config_path_without_extension)
+                warn <<~WARN.squish
+                  [DEPRECATED] The default configuration
+                  file #{config_path_without_extension} is deprecated.
+                  Use #{config_path} instead.
+                WARN
+                path = config_path_without_extension
+              end
+            end
+          end
+
           ActiveRecordDoctor.load_config_with_defaults(path)
         end
       end

--- a/lib/tasks/active_record_doctor.rake
+++ b/lib/tasks/active_record_doctor.rake
@@ -19,6 +19,6 @@ ActiveRecordDoctor::Rake::Task.new do |task|
   # This file is imported when active_record_doctor is being used as part of a
   # Rails app so it's the right place for all Rails-specific settings.
   task.deps = [:environment]
-  task.config_path = Rails.root.join(".active_record_doctor")
+  task.config_path = Rails.root.join(".active_record_doctor.rb")
   task.setup = -> { Rails.application.eager_load! }
 end

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -127,7 +127,7 @@ class Minitest::Test
     @previous_dir = Dir.pwd
 
     directory = Dir.mktmpdir("active_record_doctor")
-    @config_path = File.join(directory, ".active_record_doctor")
+    @config_path = File.join(directory, ".active_record_doctor.rb")
     File.write(@config_path, content)
     Dir.chdir(directory)
 


### PR DESCRIPTION
It now includes the `.rb` extension to assist editors with automatic syntax highlighting as well as other tools.

There continues to be a fallback to the previous `.active_record_doctor` for backward compatibility. If used, a deprecation warning is emitted to nudge the project towards the new standard.

Fixes #159