### PR TITLE
Avoid false positives on case-insensitive unique indexes when using CITEXT fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Bug fix: avoid false positives on missing case-insensitive uniqueness indexes when using [`citext`](https://www.postgresql.org/docs/current/citext.html) strings for Postgres dbs (contributed by gee-forr)
+* Bug fix: avoid false positives on missing case-insensitive uniqueness indexes when using [Postgres `citext`](https://www.postgresql.org/docs/current/citext.html) strings (contributed by gee-forr)
 
 # Version 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
-* Bug fix: avoid false positives on missing case-insensitive uniqueness indexes when using [Postgres `citext`](https://www.postgresql.org/docs/current/citext.html) strings (contributed by gee-forr)
+* Bug fix: avoid false positives on missing case-insensitive uniqueness indexes
+  when using [Postgres
+  `citext`](https://www.postgresql.org/docs/current/citext.html) strings
+  (contributed by gee-forr)
 
 # Version 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Bug fix: avoid false positives on missing case-insensitive uniqueness indexes when using [`citext`](https://www.postgresql.org/docs/current/citext.html) strings for Postgres dbs (contributed by gee-forr)
+
 # Version 1.14.0
 
 * Enhancement: the default configuration file has the .rb suffix to help editors

--- a/lib/active_record_doctor/detectors/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/detectors/missing_unique_indexes.rb
@@ -66,7 +66,7 @@ module ActiveRecordDoctor
               columns[-1] = "lower(#{columns[-1]})" unless case_sensitive
 
               next if unique_index?(model.table_name, columns)
-              next if model.columns_hash[attribute.to_s].type == :citext # citext is case-insensitive by default
+              next if model.columns_hash[attribute.to_s]&.type == :citext # citext is case-insensitive by default
 
               if case_sensitive
                 problem!(model: model, table: model.table_name, columns: columns, problem: :validations)

--- a/lib/active_record_doctor/detectors/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/detectors/missing_unique_indexes.rb
@@ -66,6 +66,7 @@ module ActiveRecordDoctor
               columns[-1] = "lower(#{columns[-1]})" unless case_sensitive
 
               next if unique_index?(model.table_name, columns)
+              next if model.columns_hash[attribute.to_s].type == :citext # citext is case-insensitive by default
 
               if case_sensitive
                 problem!(model: model, table: model.table_name, columns: columns, problem: :validations)

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -305,6 +305,10 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
   def test_case_insensitive_unique_index_with_citext
     skip unless postgresql?
 
+    ActiveRecord::Base.connection.execute(<<-SQL)
+      CREATE EXTENSION IF NOT EXISTS citext;
+    SQL
+
     Context.create_table(:users) do |t|
       t.citext :email
       t.index :email, unique: true
@@ -320,6 +324,10 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
   def test_case_insensitive_compound_unique_index_with_citext
     skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
     skip unless postgresql?
+
+    ActiveRecord::Base.connection.execute(<<-SQL)
+      CREATE EXTENSION IF NOT EXISTS citext;
+    SQL
 
     Context.create_table(:users) do |t|
       t.citext :email

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -305,11 +305,11 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
   def test_case_insensitive_unique_index_with_citext
     skip unless postgresql?
 
-    enable_extension :citext
-
     Context.create_table(:users) do |t|
       t.citext :email
       t.index :email, unique: true
+
+      t.enable_extension :citext
     end.define_model do
       validates :email, uniqueness: { case_sensitive: false }
     end
@@ -323,13 +323,13 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
     skip unless postgresql?
 
-    enable_extension :citext
-
     Context.create_table(:users) do |t|
       t.citext :email
       t.integer :organization_id
 
       t.index [:email, :organization_id], unique: true
+
+      t.enable_extension :citext
     end.define_model do
       validates :email, uniqueness: { scope: :organization_id, case_sensitive: false }
     end

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -305,9 +305,7 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
   def test_case_insensitive_unique_index_with_citext
     skip unless postgresql?
 
-    ActiveRecord::Base.connection.execute(<<-SQL)
-      CREATE EXTENSION IF NOT EXISTS citext;
-    SQL
+    enable_extension :citext
 
     Context.create_table(:users) do |t|
       t.citext :email
@@ -325,9 +323,7 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
     skip unless postgresql?
 
-    ActiveRecord::Base.connection.execute(<<-SQL)
-      CREATE EXTENSION IF NOT EXISTS citext;
-    SQL
+    enable_extension :citext
 
     Context.create_table(:users) do |t|
       t.citext :email

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -302,6 +302,37 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     refute_problems
   end
 
+  def test_case_insensitive_unique_index_with_citext
+    skip unless postgresql?
+
+    Context.create_table(:users) do |t|
+      t.citext :email
+      t.index :email, unique: true
+    end.define_model do
+      validates :email, uniqueness: { case_sensitive: false }
+    end
+
+    # CITEXT is case-insensitive, so a unique index on it is enough to
+    # guarantee case-insensitive uniqueness.
+    refute_problems
+  end
+
+  def test_case_insensitive_compound_unique_index_with_citext
+    skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
+    skip unless postgresql?
+
+    Context.create_table(:users) do |t|
+      t.citext :email
+      t.integer :organization_id
+
+      t.index [:email, :organization_id], unique: true
+    end.define_model do
+      validates :email, uniqueness: { scope: :organization_id, case_sensitive: false }
+    end
+
+    refute_problems
+  end
+
   def test_conditions_is_skipped
     assert_skipped(conditions: -> { where.not(email: nil) })
   end

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -305,11 +305,11 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
   def test_case_insensitive_unique_index_with_citext
     skip unless postgresql?
 
+    ActiveRecord::Base.connection.enable_extension(:citext)
+
     Context.create_table(:users) do |t|
       t.citext :email
       t.index :email, unique: true
-
-      t.enable_extension :citext
     end.define_model do
       validates :email, uniqueness: { case_sensitive: false }
     end
@@ -323,13 +323,13 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     skip("Expression indexes are not supported") if ActiveRecordDoctor::Utils.expression_indexes_unsupported?
     skip unless postgresql?
 
+    ActiveRecord::Base.connection.enable_extension(:citext)
+
     Context.create_table(:users) do |t|
       t.citext :email
       t.integer :organization_id
 
       t.index [:email, :organization_id], unique: true
-
-      t.enable_extension :citext
     end.define_model do
       validates :email, uniqueness: { scope: :organization_id, case_sensitive: false }
     end


### PR DESCRIPTION
This should resolve #167

Hi there @gregnavis and @fatkodima 

Please take a look at this PR and let me know if you need any changes. I wasn't able to run tests locally, so I took my best stab at getting them to work. I'll fix them if they break on CI.

Thanks so much for this great gem - I'm happy to have been able to contribute, even in this tiny way :)