### PR TITLE
missing_presence_validation: ignore columns with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Supported configuration options:
 - `ignore_models` - models whose underlying tables' columns should not be checked.
 - `ignore_attributes` - specific attributes, written as Model.attribute, that
   should not be checked.
+- `ignore_columns_with_default` - set to `true` to ignore columns with default values.
 
 ### Detecting Incorrect Presence Validations on Boolean Columns
 

--- a/lib/active_record_doctor/config/default.rb
+++ b/lib/active_record_doctor/config/default.rb
@@ -47,7 +47,8 @@ ActiveRecordDoctor.configure do
   detector :missing_presence_validation,
     enabled: true,
     ignore_models: [],
-    ignore_attributes: []
+    ignore_attributes: [],
+    ignore_columns_with_default: false
 
   detector :missing_unique_indexes,
     enabled: true,

--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -13,6 +13,9 @@ module ActiveRecordDoctor
         },
         ignore_attributes: {
           description: "specific attributes, written as Model.attribute, that should not be checked"
+        },
+        ignore_columns_with_default: {
+          description: "ignore columns with default values, should be provided as boolean"
         }
       }
 
@@ -35,7 +38,12 @@ module ActiveRecordDoctor
 
       def validator_needed?(model, column)
         ![model.primary_key, "created_at", "updated_at", "created_on", "updated_on"].include?(column.name) &&
-          (!column.null || not_null_check_constraint_exists?(model.table_name, column))
+          (!column.null || not_null_check_constraint_exists?(model.table_name, column)) &&
+          !default_value_instead_of_validation?(column)
+      end
+
+      def default_value_instead_of_validation?(column)
+        !column.default.nil? && config(:ignore_columns_with_default)
       end
 
       def validator_present?(model, column)

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -229,4 +229,29 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
 
     refute_problems
   end
+
+  def test_config_ignore_columns_with_default_columns_are_not_ignored_by_default
+    Context.create_table(:users) do |t|
+      t.integer :posts_count, null: false, default: 0
+    end.define_model
+
+    assert_problems(<<~OUTPUT)
+      add a `presence` validator to Context::User.posts_count - it's NOT NULL but lacks a validator
+    OUTPUT
+  end
+
+  def test_config_ignore_columns_with_default
+    Context.create_table(:users) do |t|
+      t.integer :posts_count, null: false, default: 0
+    end.define_model
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :missing_presence_validation,
+          ignore_columns_with_default: true
+      end
+    CONFIG
+
+    refute_problems
+  end
 end


### PR DESCRIPTION
Fixes #170.

We can add a flag for this behaviour to the checker, but I do not think this will be needed, as this looks like a legit use case for all the cases. 