### PR TITLE
Accept classes in `:ignore_models` configuration

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -323,7 +323,7 @@ module ActiveRecordDoctor
       end
 
       def ignored?(name, patterns)
-        patterns.any? { |pattern| pattern === name } # rubocop:disable Style/CaseEquality
+        patterns.any? { |pattern| pattern === name || name == pattern.to_s } # rubocop:disable Style/CaseEquality
       end
     end
   end

--- a/test/active_record_doctor/detectors/incorrect_boolean_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_boolean_presence_validation_test.rb
@@ -67,6 +67,23 @@ class ActiveRecordDoctor::Detectors::IncorrectBooleanPresenceValidationTest < Mi
     refute_problems
   end
 
+  def test_config_ignore_models_class
+    Context.create_table(:users) do |t|
+      t.boolean :active, null: false
+    end.define_model do
+      validates :active, presence: true
+    end
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :incorrect_boolean_presence_validation,
+          ignore_models: [Context::User]
+      end
+    CONFIG
+
+    refute_problems
+  end
+
   def test_global_ignore_models
     Context.create_table(:users) do |t|
       t.boolean :active, null: false


### PR DESCRIPTION
I wasted some time figuring out why class names are not working for `:ignore_models` to find out, that it accepts only strings. I think accepting classes we will improve UX a bit.