### PR TITLE
missing_non_null_constraint: ignore presence validations with specific context

### DIFF
--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -67,6 +67,7 @@ module ActiveRecordDoctor
         model.validators.select do |validator|
           validator.is_a?(ActiveRecord::Validations::PresenceValidator) &&
             !validator.options[:allow_nil] &&
+            validator.options[:on].blank? &&
             (rails_belongs_to_presence_validator?(validator) || !conditional_validator?(validator))
         end
       end

--- a/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
+++ b/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
@@ -137,6 +137,16 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
     refute_problems
   end
 
+  def test_validators_with_specific_context_on_optional_columns_are_allowed
+    Context.create_table(:users) do |t|
+      t.string :name, null: true
+    end.define_model do
+      validates :name, presence: true, on: :create
+    end
+
+    refute_problems
+  end
+
   def test_models_with_non_existent_tables_are_skipped
     Context.define_model(:User)
 


### PR DESCRIPTION
Fixes #188.