### PR TITLE
Fix configuration option key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Supported configuration options:
 
 - `enabled` - set to `false` to disable the detector altogether
 - `ignore_tables` - tables whose indexes should never be reported as extraneous.
-- `ignore_columns` - indexes that should never be reported as extraneous.
+- `ignore_indexes` - indexes that should never be reported as extraneous.
 
 ### Detecting Unindexed `deleted_at` Columns
 


### PR DESCRIPTION
The configuration is `ignore_indexes` not `ignore_columns`.

See https://github.com/gregnavis/active_record_doctor/blob/4ee897cac9d1aea7d91e28f0e3d98dcb13922405/lib/active_record_doctor/detectors/extraneous_indexes.rb#L14