### PR TITLE
missing_presence_validation: ignore type columns for required polymorphic `belongs_to` associations

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -81,7 +81,8 @@ module ActiveRecordDoctor
         allowed_attributes = [column.name.to_sym]
 
         belongs_to = model.reflect_on_all_associations(:belongs_to).find do |reflection|
-          reflection.foreign_key == column.name
+          reflection.foreign_key == column.name ||
+            (reflection.polymorphic? && reflection.foreign_type == column.name)
         end
         allowed_attributes << belongs_to.name.to_sym if belongs_to
 

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -42,6 +42,17 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
     refute_problems
   end
 
+  def test_non_null_type_column_is_not_reported_if_association_validation_present
+    Context.create_table(:comments) do |t|
+      t.integer :commentable_id, null: false
+      t.string :commentable_type, null: false
+    end.define_model do
+      belongs_to :commentable, polymorphic: true, required: true
+    end
+
+    refute_problems
+  end
+
   def test_not_null_column_is_not_reported_if_habtm_association
     Context.create_table(:users).define_model do
       has_and_belongs_to_many :projects, class_name: "Context::Project"


### PR DESCRIPTION
Currently, if there is a *required* polymorphic `belongs_to` association with non null for both columns, `missing_presence_validation` suggests to add a `presence` validation for a type column, which is not needed.