### PR TITLE
Require ruby 3.1+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # We upgrade to new versions of rubocop manually so it won't harm to enable all
 # new cops.
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
   NewCops: enable
   SuggestExtensions: false
 
@@ -123,6 +123,10 @@ Naming/PredicateName:
   AllowedMethods:
     - "has_presence_validator?"
     - "has_mandatory_presence_validator?"
+
+# Looks cryptic.
+Naming/BlockForwarding:
+  Enabled: false
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec

--- a/active_record_doctor.gemspec
+++ b/active_record_doctor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.metadata["rubygems_mfa_required"] = "true"
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.1.0"
 
   s.add_dependency "activerecord", ACTIVE_RECORD_SPEC
 

--- a/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
+++ b/lib/generators/active_record_doctor/add_indexes/add_indexes_generator.rb
@@ -19,7 +19,7 @@ module ActiveRecordDoctor
 
     private
 
-    INPUT_LINE = /^add an index on (\w+)\((.+)\) - .*$/.freeze
+    INPUT_LINE = /^add an index on (\w+)\((.+)\) - .*$/
     private_constant :INPUT_LINE
 
     def read_migration_descriptions(path)


### PR DESCRIPTION
CI tests against ruby 3.1+, rails 7 requires ruby 3.1+ and rubocop.yml was also inconsistent.