### PR TITLE
incorrect_dependent_option: Fix infinite recursion when association of the same class as model class

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
+++ b/lib/active_record_doctor/detectors/incorrect_dependent_option.rb
@@ -147,14 +147,16 @@ module ActiveRecordDoctor
         end
       end
 
-      def deletable?(model)
+      def deletable?(model, deletable_models = [])
+        return true if deletable_models.include?(model)
+
         !defines_destroy_callbacks?(model) &&
           dependent_models(model).all? do |dependent_model|
             foreign_key = foreign_key(dependent_model.table_name, model.table_name)
 
             foreign_key.nil? ||
               foreign_key.on_delete == :nullify || (
-                foreign_key.on_delete == :cascade && deletable?(dependent_model)
+                foreign_key.on_delete == :cascade && deletable?(dependent_model, deletable_models + [model])
               )
           end
       end

--- a/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_dependent_option_test.rb
@@ -213,6 +213,16 @@ class ActiveRecordDoctor::Detectors::IncorrectDependentOptionTest < Minitest::Te
     refute_problems
   end
 
+  def test_cascade_and_same_class_association
+    Context.create_table(:users) do |t|
+      t.references :parent, foreign_key: { to_table: :users, on_delete: :cascade }
+    end.define_model do
+      has_many :children, class_name: "Context::User", foreign_key: :parent_id
+    end
+
+    refute_problems
+  end
+
   def test_no_dependent_suggests_nothing
     Context.create_table(:companies) do
     end.define_model do


### PR DESCRIPTION
incorrect_dependent_options produces an infinite recursion and stack overflow when there is a `:cascade` foreign key and the association is of the same class as the owner model (for example, parent-child relationships).