### PR TITLE
missing_foreign_keys: consider column type for foreign key candidates

### DIFF
--- a/lib/active_record_doctor/detectors/missing_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/missing_foreign_keys.rb
@@ -28,7 +28,7 @@ module ActiveRecordDoctor
             # We need to skip polymorphic associations as they can reference
             # multiple tables but a foreign key constraint can reference
             # a single predefined table.
-            next unless named_like_foreign_key?(column)
+            next unless looks_like_foreign_key?(column)
             next if foreign_key?(table, column)
             next if polymorphic_foreign_key?(table, column)
 
@@ -37,8 +37,11 @@ module ActiveRecordDoctor
         end
       end
 
-      def named_like_foreign_key?(column)
-        column.name.end_with?("_id")
+      def looks_like_foreign_key?(column)
+        type = column.type.to_s
+
+        column.name.end_with?("_id") &&
+          (type == "integer" || type.include?("uuid"))
       end
 
       def foreign_key?(table, column)

--- a/test/active_record_doctor/detectors/missing_foreign_keys_test.rb
+++ b/test/active_record_doctor/detectors/missing_foreign_keys_test.rb
@@ -21,6 +21,26 @@ class ActiveRecordDoctor::Detectors::MissingForeignKeysTest < Minitest::Test
     refute_problems
   end
 
+  def test_non_integer_missing_foreign_key_is_reported
+    Context.create_table(:users) do |t|
+      t.string :external_id
+    end
+
+    refute_problems
+  end
+
+  def test_uuid_missing_foreign_key_is_reported
+    require_uuid_column_type!
+
+    Context.create_table(:users) do |t|
+      t.uuid :company_id
+    end
+
+    assert_problems(<<~OUTPUT)
+      create a foreign key on users.company_id - looks like an association without a foreign key constraint
+    OUTPUT
+  end
+
   def test_config_ignore_models
     Context.create_table(:companies)
     Context.create_table(:users) do |t|


### PR DESCRIPTION
The `missing_foreign_keys` checker does not currently consider the type of the column and so strings, booleans etc are marked as bad. 

We currently muted 100+ cases and 100% of these cases are false positives. I think it is reasonable to consider only integer-like and uuid columns. It is possible someone uses a string column as a foreign key, but I expect this to happen in 0.001% cases and it is better to miss this, than the need to pollute the config file with a bunch of ignores.