### PR TITLE
unindexed_foreign_keys: consider column type for foreign key candidates

### DIFF
--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -244,6 +244,13 @@ module ActiveRecordDoctor
         end
       end
 
+      def looks_like_foreign_key?(column)
+        type = column.type.to_s
+
+        column.name.end_with?("_id") &&
+          (type == "integer" || type.include?("uuid"))
+      end
+
       def each_foreign_key(table_name)
         log("Iterating over foreign keys on #{table_name}") do
           connection.foreign_keys(table_name).each do |foreign_key|

--- a/lib/active_record_doctor/detectors/missing_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/missing_foreign_keys.rb
@@ -37,13 +37,6 @@ module ActiveRecordDoctor
         end
       end
 
-      def looks_like_foreign_key?(column)
-        type = column.type.to_s
-
-        column.name.end_with?("_id") &&
-          (type == "integer" || type.include?("uuid"))
-      end
-
       def foreign_key?(table, column)
         connection.foreign_keys(table).any? do |foreign_key|
           foreign_key.options[:column] == column.name

--- a/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
@@ -27,7 +27,7 @@ module ActiveRecordDoctor
       def detect
         each_table(except: config(:ignore_tables)) do |table|
           each_column(table, except: config(:ignore_columns)) do |column|
-            next unless named_like_foreign_key?(column) || foreign_key?(table, column)
+            next unless looks_like_foreign_key?(column) || foreign_key?(table, column)
             next if indexed?(table, column)
             next if indexed_as_polymorphic?(table, column)
             next if connection.primary_key(table) == column.name
@@ -44,10 +44,6 @@ module ActiveRecordDoctor
             problem!(table: table, columns: columns)
           end
         end
-      end
-
-      def named_like_foreign_key?(column)
-        column.name.end_with?("_id")
       end
 
       def foreign_key?(table, column)

--- a/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
+++ b/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
@@ -52,6 +52,26 @@ class ActiveRecordDoctor::Detectors::UnindexedForeignKeysTest < Minitest::Test
     refute_problems
   end
 
+  def test_non_integer_unindexed_foreign_key_is_not_reported
+    Context.create_table(:users) do |t|
+      t.string :external_id
+    end
+
+    refute_problems
+  end
+
+  def test_uuid_unindexed_foreign_key_is_reported
+    require_uuid_column_type!
+
+    Context.create_table(:users) do |t|
+      t.uuid :company_id
+    end
+
+    assert_problems(<<~OUTPUT)
+      add an index on users(company_id) - foreign keys are often used in database lookups and should be indexed for performance reasons
+    OUTPUT
+  end
+
   def test_indexed_foreign_key_is_not_reported
     Context.create_table(:companies)
     Context.create_table(:users) do |t|


### PR DESCRIPTION
Follow up to #204.

I realized, that unindexed_foreign_keys checker should do the same.