### PR TITLE
missing_presence_validation: ignore columns with default functions

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -44,7 +44,7 @@ module ActiveRecordDoctor
       end
 
       def default_value_instead_of_validation?(column)
-        !column.default.nil? && config(:ignore_columns_with_default)
+        (!column.default.nil? || column.default_function) && config(:ignore_columns_with_default)
       end
 
       def validator_present?(model, column)

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -264,9 +264,24 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
     OUTPUT
   end
 
-  def test_config_ignore_columns_with_default
+  def test_config_ignore_columns_with_default_when_using_value
     Context.create_table(:users) do |t|
       t.integer :posts_count, null: false, default: 0
+    end.define_model
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :missing_presence_validation,
+          ignore_columns_with_default: true
+      end
+    CONFIG
+
+    refute_problems
+  end
+
+  def test_config_ignore_columns_with_default_when_using_function
+    Context.create_table(:users) do |t|
+      t.timestamp :started_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
     end.define_model
 
     config_file(<<-CONFIG)


### PR DESCRIPTION
Follow up to https://github.com/gregnavis/active_record_doctor/pull/171.

Forgot to also ignore default functions (like `default: -> { "CURRENT_TIMESTAMP" }`) in that PR.