### PR TITLE
missing_presence_validation: ignore all columns with proper inclusion/exclusion validations

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -48,12 +48,9 @@ module ActiveRecordDoctor
       end
 
       def validator_present?(model, column)
-        if column.type == :boolean
-          inclusion_validator_present?(model, column) ||
-            exclusion_validator_present?(model, column)
-        else
+        inclusion_validator_present?(model, column) ||
+          exclusion_validator_present?(model, column) ||
           presence_validator_present?(model, column)
-        end
       end
 
       def inclusion_validator_present?(model, column)
@@ -62,7 +59,7 @@ module ActiveRecordDoctor
           return true if validator_items.is_a?(Proc)
 
           validator.is_a?(ActiveModel::Validations::InclusionValidator) &&
-            validator.attributes.include?(column.name.to_sym) &&
+            validator.attributes.map(&:to_s).include?(column.name) &&
             !validator_items.include?(nil)
         end
       end


### PR DESCRIPTION
Just noticed, that `missing_presence_validation` checker marks `enum ..., validate: true` as offences, even though these are false positives. 

`enum` definition uses `validates_inclusion_of` under the hood, but the checker considers only boolean columns having proper `inclusion`/`exclusion` validations as good. I think, this should be extended to other column types.