### PR TITLE
`unindexed_foreign_keys` validation for composite primary key on HABTM

### DIFF
--- a/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/unindexed_foreign_keys.rb
@@ -54,7 +54,9 @@ module ActiveRecordDoctor
 
       def indexed?(table, column)
         connection.indexes(table).any? do |index|
-          index.columns.first == column.name
+          index.columns.first == column.name ||
+            (connection.primary_key(table).is_a?(Array) &&
+             connection.primary_key(table).include?(column.name))
         end
       end
 

--- a/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
+++ b/test/active_record_doctor/detectors/unindexed_foreign_keys_test.rb
@@ -178,4 +178,17 @@ class ActiveRecordDoctor::Detectors::UnindexedForeignKeysTest < Minitest::Test
 
     refute_problems
   end
+
+  def test_habtm_table_with_composite_primary_key_is_not_reported
+    require_non_indexed_foreign_keys!
+
+    Context.create_table(:companies)
+    Context.create_table(:users)
+    Context.create_table(:companies_users, primary_key: [:company_id, :user_id]) do |t|
+      t.references :companies, foreign_key: true, null: false
+      t.references :partner, foreign_key: true, null: false
+    end
+
+    refute_problems
+  end
 end


### PR DESCRIPTION
## Fix false positive for HABTM tables with composite primary keys

### Problem
The UnindexedForeignKeys detector currently reports false positives for HABTM 
(Has And Belongs To Many) tables that use composite primary keys. It suggests 
adding indexes that already exist as part of the primary key.

### Solution
Modified the `indexed?` method to recognize columns that are part of composite 
primary keys. This prevents false positives while maintaining the original 
functionality for single-column indexes.

### Example
Given a HABTM table:
```sql
CREATE TABLE companies_users (
  company_id bigint NOT NULL,
  user_id bigint NOT NULL,
  PRIMARY KEY (company_id, user_id)
);
```

### Testing
Pointed the repo at this branch and ran the UnindexedForeignKeys command. Has fixed the issue for my repo.