### PR TITLE
incorrect_length_validation: ignore STI models

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_length_validation.rb
+++ b/lib/active_record_doctor/detectors/incorrect_length_validation.rb
@@ -41,6 +41,9 @@ module ActiveRecordDoctor
             next if model_maximum == database_maximum
             next if database_maximum && covered_by_inclusion_validation?(model, column.name.to_sym, database_maximum)
 
+            # Add violation only to the root model of STI.
+            next if (model_maximum.nil? || column.limit.nil?) && sti_subclass?(model)
+
             problem!(
               model: model.name,
               column: column,
@@ -73,6 +76,11 @@ module ActiveRecordDoctor
 
         values = inclusion_validator.options[:in] || inclusion_validator.options[:within]
         values.is_a?(Array) && values.all? { |value| value.is_a?(String) && value.size <= limit }
+      end
+
+      def sti_subclass?(model)
+        model.columns_hash.include?(model.inheritance_column.to_s) &&
+          model.base_class != model
       end
     end
   end

--- a/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
@@ -50,6 +50,20 @@ class ActiveRecordDoctor::Detectors::IncorrectLengthValidationTest < Minitest::T
     OUTPUT
   end
 
+  def test_sti_subclasses_are_ignored
+    Context.create_table(:users) do |t|
+      t.string :email, limit: 64
+      t.string :type, null: false
+    end.define_model do
+    end
+
+    Context.define_model(:Client, Context::User)
+
+    assert_problems(<<~OUTPUT)
+      the schema limits users.email to 64 characters but there's no length validator on Context::User.email - remove the database limit or add the validator
+    OUTPUT
+  end
+
   def test_no_validation_and_no_limit_is_ok
     require_arbitrary_long_text_columns!
 


### PR DESCRIPTION
If using STI and there is no validation on the model, but there is a limit in the database for the field, `incorrect_length_validation` checker produces violations for both root model and its children.

I think this is unnecessary and should be reported only for the root model, because this is the place where it should be fixed.