### PR TITLE
Make checkers agnostic of validator attributes types

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_boolean_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/incorrect_boolean_presence_validation.rb
@@ -37,7 +37,8 @@ module ActiveRecordDoctor
 
       def has_presence_validator?(model, column)
         model.validators.any? do |validator|
-          validator.kind == :presence && validator.attributes.include?(column.name.to_sym)
+          attributes = validator.attributes.map(&:to_s)
+          validator.kind == :presence && attributes.include?(column.name)
         end
       end
     end

--- a/lib/active_record_doctor/detectors/incorrect_length_validation.rb
+++ b/lib/active_record_doctor/detectors/incorrect_length_validation.rb
@@ -33,7 +33,7 @@ module ActiveRecordDoctor
       def detect
         each_model(except: config(:ignore_models), existing_tables_only: true) do |model|
           each_attribute(model, except: config(:ignore_attributes), type: [:string, :text]) do |column|
-            model_maximum = maximum_allowed_by_validations(model, column.name.to_sym)
+            model_maximum = maximum_allowed_by_validations(model, column.name)
             next if model_maximum == column.limit
 
             problem!(
@@ -49,9 +49,11 @@ module ActiveRecordDoctor
 
       def maximum_allowed_by_validations(model, column)
         length_validator = model.validators.find do |validator|
+          attributes = validator.attributes.map(&:to_s)
+
           validator.kind == :length &&
             validator.options.include?(:maximum) &&
-            validator.attributes.include?(column)
+            attributes.include?(column)
         end
         length_validator ? length_validator.options[:maximum] : nil
       end

--- a/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
+++ b/lib/active_record_doctor/detectors/missing_non_null_constraint.rb
@@ -70,10 +70,10 @@ module ActiveRecordDoctor
         end
 
         required_presence_validators(model).any? do |validator|
-          attributes = validator.attributes
+          attributes = validator.attributes.map(&:to_s)
 
-          attributes.include?(column.name.to_sym) ||
-            (belongs_to && attributes.include?(belongs_to.name.to_sym))
+          attributes.include?(column.name) ||
+            (belongs_to && attributes.include?(belongs_to.name.to_s))
         end
       end
 

--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -58,8 +58,9 @@ module ActiveRecordDoctor
           validator_items = inclusion_validator_items(validator)
           return true if validator_items.is_a?(Proc)
 
+          attributes = validator.attributes.map(&:to_s)
           validator.is_a?(ActiveModel::Validations::InclusionValidator) &&
-            validator.attributes.map(&:to_s).include?(column.name) &&
+            attributes.include?(column.name) &&
             !validator_items.include?(nil)
         end
       end
@@ -69,23 +70,26 @@ module ActiveRecordDoctor
           validator_items = inclusion_validator_items(validator)
           return true if validator_items.is_a?(Proc)
 
+          attributes = validator.attributes.map(&:to_s)
           validator.is_a?(ActiveModel::Validations::ExclusionValidator) &&
-            validator.attributes.include?(column.name.to_sym) &&
+            attributes.include?(column.name) &&
             validator_items.include?(nil)
         end
       end
 
       def presence_validator_present?(model, column)
-        allowed_attributes = [column.name.to_sym]
+        allowed_attributes = [column.name]
 
         belongs_to = model.reflect_on_all_associations(:belongs_to).find do |reflection|
           reflection.foreign_key == column.name
         end
-        allowed_attributes << belongs_to.name.to_sym if belongs_to
+        allowed_attributes << belongs_to.name.to_s if belongs_to
 
         model.validators.any? do |validator|
+          attributes = validator.attributes.map(&:to_s)
+
           validator.is_a?(ActiveRecord::Validations::PresenceValidator) &&
-            (validator.attributes & allowed_attributes).present?
+            (attributes & allowed_attributes).present?
         end
       end
 

--- a/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
@@ -6,7 +6,7 @@ class ActiveRecordDoctor::Detectors::IncorrectLengthValidationTest < Minitest::T
       t.string :email, limit: 64
       t.string :name, limit: 32
     end.define_model do
-      validates :email, length: { maximum: 64 }
+      validates "email", length: { maximum: 64 } # use a string on purpose
       validates :name, length: { maximum: 32 }
     end
 


### PR DESCRIPTION
Rails validators do not convert passed attributes to either string or symbols. But some checkers assume that attributes are always of symbol type.

This is problematic for example for cases when the attribute is some interpolated string and not converted to a symbol, which I just encountered in my project.