### PR TITLE
incorrect_length_validation-check: Consider check constraints with column lenght limits

### DIFF
--- a/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
+++ b/test/active_record_doctor/detectors/incorrect_length_validation_test.rb
@@ -13,9 +13,33 @@ class ActiveRecordDoctor::Detectors::IncorrectLengthValidationTest < Minitest::T
     refute_problems
   end
 
+  def test_validation_and_check_constraint_limit_equal_is_ok
+    Context.create_table(:users) do |t|
+      t.string :email
+      t.check_constraint "length(email) <= 64"
+    end.define_model do
+      validates :email, length: { maximum: 64 }
+    end
+
+    refute_problems
+  end
+
   def test_validation_and_limit_different_is_error
     Context.create_table(:users) do |t|
       t.string :email, limit: 64
+    end.define_model do
+      validates :email, length: { maximum: 32 }
+    end
+
+    assert_problems(<<~OUTPUT)
+      the schema limits users.email to 64 characters but the length validator on Context::User.email enforces a maximum of 32 characters - set both limits to the same value or remove both
+    OUTPUT
+  end
+
+  def test_validation_and_check_constraint_limit_different_is_error
+    Context.create_table(:users) do |t|
+      t.string :email
+      t.check_constraint "length(email) <= 64"
     end.define_model do
       validates :email, length: { maximum: 32 }
     end
@@ -42,6 +66,18 @@ class ActiveRecordDoctor::Detectors::IncorrectLengthValidationTest < Minitest::T
   def test_no_validation_and_limit_is_error
     Context.create_table(:users) do |t|
       t.string :email, limit: 64
+    end.define_model do
+    end
+
+    assert_problems(<<~OUTPUT)
+      the schema limits users.email to 64 characters but there's no length validator on Context::User.email - remove the database limit or add the validator
+    OUTPUT
+  end
+
+  def test_no_validation_and_check_constraint_limit_is_error
+    Context.create_table(:users) do |t|
+      t.string :email
+      t.check_constraint "length(email) <= 64"
     end.define_model do
     end
 


### PR DESCRIPTION
In postgres, when adding a limit to some existing text column, it will exclusively lock the table (preventing reads and writes) until the column data is verified and the column is changed. This is problematic for large tables and a different approach is usually used - check constraints with length limit (e.g. `CHECK (length(email) <= 64)`).

This PR extends existing checker to account for this.