### PR TITLE
missing_foreign_keys: Ignore tables which records are destroyed async

### DIFF
--- a/lib/active_record_doctor/detectors/missing_foreign_keys.rb
+++ b/lib/active_record_doctor/detectors/missing_foreign_keys.rb
@@ -31,6 +31,7 @@ module ActiveRecordDoctor
             next unless looks_like_foreign_key?(column)
             next if foreign_key?(table, column)
             next if polymorphic_foreign_key?(table, column)
+            next if model_destroyed_async?(table, column)
 
             problem!(table: table, column: column.name)
           end
@@ -47,6 +48,18 @@ module ActiveRecordDoctor
         type_column_name = column.name.sub(/_id\Z/, "_type")
         connection.columns(table).any? do |another_column|
           another_column.name == type_column_name
+        end
+      end
+
+      def model_destroyed_async?(table, column)
+        # Check if there are any models having `has_many ..., dependent: :destroy_async`
+        # referencing the specified model.
+        models.any? do |model|
+          model.reflect_on_all_associations(:has_many).any? do |reflection|
+            reflection.options[:dependent] == :destroy_async &&
+              reflection.foreign_key == column.name &&
+              reflection.klass.table_name == table
+          end
         end
       end
     end

--- a/test/active_record_doctor/detectors/missing_foreign_keys_test.rb
+++ b/test/active_record_doctor/detectors/missing_foreign_keys_test.rb
@@ -41,6 +41,20 @@ class ActiveRecordDoctor::Detectors::MissingForeignKeysTest < Minitest::Test
     OUTPUT
   end
 
+  def test_destroy_async_is_not_reported
+    Context.create_table(:companies).define_model do
+      class_attribute :destroy_association_async_job, default: Class.new
+
+      has_many :users, dependent: :destroy_async
+    end
+
+    Context.create_table(:users) do |t|
+      t.references :company, foreign_key: false
+    end.define_model
+
+    refute_problems
+  end
+
   def test_config_ignore_models
     Context.create_table(:companies)
     Context.create_table(:users) do |t|


### PR DESCRIPTION
Currently, missing_foreign_keys erroneously suggests adding foreign keys to columns for rows, which are destroyed async from some other parent record. This PR fixes that.