### PR TITLE
incorrect_length_validation: Consider `inclusion` validations as an alternative

### DIFF
--- a/lib/active_record_doctor/detectors/incorrect_length_validation.rb
+++ b/lib/active_record_doctor/detectors/incorrect_length_validation.rb
@@ -33,27 +33,46 @@ module ActiveRecordDoctor
       def detect
         each_model(except: config(:ignore_models), existing_tables_only: true) do |model|
           each_attribute(model, except: config(:ignore_attributes), type: [:string, :text]) do |column|
-            model_maximum = maximum_allowed_by_validations(model, column.name.to_sym)
-            next if model_maximum == column.limit
+            model_maximum = maximum_allowed_by_length_validation(model, column.name.to_sym)
+            database_maximum = column.limit
+            next if model_maximum == database_maximum
+            next if column.limit && covered_by_inclusion_validation?(model, column.name.to_sym, database_maximum)
 
             problem!(
               model: model.name,
               attribute: column.name,
               table: model.table_name,
-              database_maximum: column.limit,
+              database_maximum: database_maximum,
               model_maximum: model_maximum
             )
           end
         end
       end
 
-      def maximum_allowed_by_validations(model, column)
+      def maximum_allowed_by_length_validation(model, column)
         length_validator = model.validators.find do |validator|
           validator.kind == :length &&
             validator.options.include?(:maximum) &&
             validator.attributes.include?(column)
         end
         length_validator ? length_validator.options[:maximum] : nil
+      end
+
+      def covered_by_inclusion_validation?(model, column, limit)
+        inclusion_validator = model.validators.find do |validator|
+          validator.kind == :inclusion &&
+            validator.attributes.include?(column)
+        end
+
+        if inclusion_validator
+          values = inclusion_validator.options[:in] || inclusion_validator.options[:within]
+          if values.is_a?(Array) && values.all?(String)
+            longest_value = values.max_by(&:size)
+            longest_value.size <= limit
+          end
+        else
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #205.