### PR TITLE
missing_unique_indexes: Fix ignoring case insensitive columns

### DIFF
--- a/lib/active_record_doctor/detectors/missing_unique_indexes.rb
+++ b/lib/active_record_doctor/detectors/missing_unique_indexes.rb
@@ -71,13 +71,13 @@ module ActiveRecordDoctor
             validator.attributes.each do |attribute|
               columns = resolve_attributes(model, scope + [attribute])
 
-              next if ignore_columns.include?("#{model.name}(#{columns.join(',')})")
-
               # citext is case-insensitive by default, so it doesn't have to be
               # lowered.
               if !case_sensitive && model.columns_hash[columns[-1]].type != :citext
                 columns[-1] = "lower(#{columns[-1]})"
               end
+
+              next if ignore_columns.include?("#{model.name}(#{columns.join(',')})")
               next if unique_index?(model.table_name, columns)
 
               if case_sensitive

--- a/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
+++ b/test/active_record_doctor/detectors/missing_unique_indexes_test.rb
@@ -589,6 +589,23 @@ class ActiveRecordDoctor::Detectors::MissingUniqueIndexesTest < Minitest::Test
     refute_problems
   end
 
+  def test_config_ignore_case_insensitive_columns
+    Context.create_table(:users) do |t|
+      t.string :email
+    end.define_model do
+      validates :email, uniqueness: { case_sensitive: false }
+    end
+
+    config_file(<<-CONFIG)
+      ActiveRecordDoctor.configure do |config|
+        config.detector :missing_unique_indexes,
+          ignore_columns: ["Context::User(lower(email))"]
+      end
+    CONFIG
+
+    refute_problems
+  end
+
   def test_config_ignore_columns_for_has_one
     Context.create_table(:users).define_model do
       has_one :account, class_name: "Context::Account"


### PR DESCRIPTION
Case insensitive columns in missing_unique_indexes checker were not properly ignored.