### PR TITLE
Skip models connected to non-primary databases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source "https://rubygems.org"
 gemspec
+
+# minitest 6.0 removed run_one_method which minitest-fork_executor depends on
+gem "minitest", "~> 5.0"

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ ActiveRecordDoctor.configure do
 end
 ```
 
+### Multiple Databases
+
+`active_record_doctor` currently only analyzes models connected to the primary
+database. Models that use a different database connection — whether via
+`establish_connection`, `connects_to`, or by inheriting from an abstract class
+with its own connection — are automatically skipped by all detectors.
+
+This means that if you have gems or parts of your application that connect to a
+secondary database, their models won't be checked and won't cause errors.
+
 ### Indexing Unindexed Foreign Keys
 
 Foreign keys should be indexed unless it's proven ineffective. However, Rails

--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -156,7 +156,10 @@ module ActiveRecordDoctor
       end
 
       def models
-        ActiveRecord::Base.descendants.sort_by(&:name)
+        base_pool = ActiveRecord::Base.connection_pool
+        ActiveRecord::Base.descendants
+          .reject { |model| model.connection_pool != base_pool }
+          .sort_by(&:name)
       end
 
       def underscored_name

--- a/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
+++ b/test/active_record_doctor/detectors/missing_non_null_constraint_test.rb
@@ -349,4 +349,17 @@ class ActiveRecordDoctor::Detectors::MissingNonNullConstraintTest < Minitest::Te
       add `NOT NULL` to users.updated_on - timestamp columns are set automatically by Active Record and allowing NULL may lead to inconsistencies introduced by bulk operations
     OUTPUT
   end
+
+  def test_models_with_non_primary_connection_are_skipped
+    # Models connected to a secondary database should be silently skipped.
+    # Previously this would crash with e.g. PG::UndefinedTable when the
+    # secondary table didn't exist in the primary database (see #149).
+    SecondaryContext.create_table(:users) do |t|
+      t.string :name, null: true
+    end.define_model do
+      validates :name, presence: true
+    end
+
+    refute_problems
+  end
 end

--- a/test/active_record_doctor/detectors/undefined_table_references_test.rb
+++ b/test/active_record_doctor/detectors/undefined_table_references_test.rb
@@ -52,4 +52,12 @@ class ActiveRecordDoctor::Detectors::UndefinedTableReferencesTest < Minitest::Te
 
     refute_problems
   end
+
+  def test_models_with_non_primary_connection_are_skipped
+    # Models connected to a secondary database should be silently skipped,
+    # not reported as referencing undefined tables (see #149).
+    SecondaryContext.create_table(:users).define_model
+
+    refute_problems
+  end
 end

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -8,9 +8,11 @@ require "uri"
 
 require "logger"
 require "active_record"
-require "pg"
-require "mysql2"
-require "sqlite3"
+%w[pg mysql2 sqlite3].each do |adapter_gem|
+  require adapter_gem
+rescue LoadError
+  # Not all adapters need to be installed; only the one matching DATABASE_ADAPTER is required.
+end
 
 adapter = ENV.fetch("DATABASE_ADAPTER")
 
@@ -90,6 +92,8 @@ class SecondaryRecord < ApplicationRecord
 end
 
 SecondaryRecord.establish_connection :secondary
+
+SecondaryContext = TransientRecord.context_for SecondaryRecord
 
 if ActiveRecord.version >= Gem::Version.new("7.1")
   # See https://github.com/rails/rails/pull/46522 for details.


### PR DESCRIPTION
## Summary

Fixes #149 — `active_record_doctor` crashes when the application has models
connected to a different database (e.g. a gem using `establish_connection`
to SQLite while the app uses PostgreSQL).

**Root cause:** `Base#connection` is hardcoded to `ActiveRecord::Base.connection`
(the primary database). When `missing_non_null_constraint` calls
`models.select(&:table_exists?)`, it uses each model's own connection — so a
secondary-DB model returns `true`. Then `connection.columns(table)` queries the
primary connection for that table, which doesn't exist there → crash.

**Fix:** Filter `Base#models` to exclude models whose `connection_pool` differs
from `ActiveRecord::Base.connection_pool`. This is a single guard that protects
all detectors — no per-detector changes needed.

## Changes

- **`lib/active_record_doctor/detectors/base.rb`** — Filter `models` by connection pool
- **`test/setup.rb`** — Add `SecondaryContext` for multi-DB tests; graceful adapter loading
- **`test/.../missing_non_null_constraint_test.rb`** — Test: secondary-DB model doesn't crash
- **`test/.../undefined_table_references_test.rb`** — Test: secondary-DB model isn't flagged
- **`README.md`** — Document "Multiple Databases" behavior
- **`Gemfile`** — Pin minitest ~> 5.0 (minitest 6 broke minitest-fork_executor)

## Test plan

- [x] New tests fail without the fix (RED)
- [x] New tests pass with the fix (GREEN)
- [x] Full suite: 257 runs, 0 failures, 0 errors (39 adapter-specific skips)

Disclaimer: This PR was created with the help of AI