### PR TITLE
Fix missing_presence_validation crash when :in is a Symbol

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -93,6 +93,7 @@ module ActiveRecordDoctor
               when ActiveModel::Validations::InclusionValidator
                 validator_items = inclusion_or_exclusion_validator_items(validator)
                 (validator.attributes & attribute_names).present? &&
+                  !validator_items.is_a?(Symbol) &&
                   (validator_items.is_a?(Proc) || validator_items.exclude?(nil))
 
               # An exclusion validator ensures the column is not nil if it covers
@@ -100,6 +101,7 @@ module ActiveRecordDoctor
               when ActiveModel::Validations::ExclusionValidator
                 validator_items = inclusion_or_exclusion_validator_items(validator)
                 (validator.attributes & attribute_names).present? &&
+                  !validator_items.is_a?(Symbol) &&
                   (validator_items.is_a?(Proc) || validator_items.include?(nil))
 
               end

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -133,6 +133,38 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
     refute_problems
   end
 
+  def test_non_null_column_is_not_reported_if_inclusion_in_is_symbol
+    Context.create_table(:users) do |t|
+      t.string :role, null: false
+    end.define_model do
+      validates :role, inclusion: { in: :allowed_roles }
+
+      def allowed_roles
+        ["admin", "user"]
+      end
+    end
+
+    assert_problems(<<~OUTPUT)
+      add a `presence` validator to Context::User.role - it's NOT NULL but lacks a validator
+    OUTPUT
+  end
+
+  def test_non_null_column_is_not_reported_if_exclusion_in_is_symbol
+    Context.create_table(:users) do |t|
+      t.string :role, null: false
+    end.define_model do
+      validates :role, exclusion: { in: :disallowed_roles }
+
+      def disallowed_roles
+        ["banned"]
+      end
+    end
+
+    assert_problems(<<~OUTPUT)
+      add a `presence` validator to Context::User.role - it's NOT NULL but lacks a validator
+    OUTPUT
+  end
+
   def test_non_null_boolean_is_reported_if_nil_not_excluded
     Context.create_table(:users) do |t|
       t.boolean :active, null: false


### PR DESCRIPTION
## Summary
- Fixes `NoMethodError: undefined method 'exclude?' for an instance of Symbol` when a model uses `validates :attr, inclusion: { in: :method_name }`
- Handles Symbol `:in` values by treating them as unresolvable (same conservative approach as Proc, but reports the column since we can't statically verify nil exclusion)
- Adds tests for both inclusion and exclusion validators with Symbol `:in`

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)