### PR TITLE
Add multidb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ to open an issue or a PR with the fix.
 ACTIVE_RECORD_DOCTOR_DEBUG=1 bundle exec rake active_record_doctor
 ```
 
+### Application Record base class
+
+Rails applications often use `ApplicationRecord` instead of inheriting directly from `ActiveRecord::Base`. Detectors resolve models and connections from a configurable root class:
+
+- **`ACTIVE_RECORD_DOCTOR_BASE_CLASS`** — constant name (e.g. `ApplicationRecord`). Defaults to `ActiveRecord::Base` when unset. Useful when multiple abstract roots exist (for example multi-database setups) so checks use the intended connection and model hierarchy.
+
+Example:
+
+```
+ACTIVE_RECORD_DOCTOR_BASE_CLASS=ApplicationRecord bundle exec rake active_record_doctor
+```
+
 ### Configuration
 
 `active_record_doctor` can be configured to better suit your project's needs.

--- a/active_record_doctor.gemspec
+++ b/active_record_doctor.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activerecord", ACTIVE_RECORD_SPEC
 
+  # minitest-fork_executor 1.x still hooks Minitest.run_one_method (removed in Minitest 6).
+  s.add_development_dependency "minitest", ">= 5.1", "< 6"
   s.add_development_dependency "minitest-fork_executor", "~> 1.0.2"
   s.add_development_dependency "mysql2", "~> 0.5.6"
   s.add_development_dependency "pg", "~> 1.5.9"

--- a/lib/active_record_doctor/detectors/base.rb
+++ b/lib/active_record_doctor/detectors/base.rb
@@ -38,10 +38,11 @@ module ActiveRecordDoctor
         end
       end
 
-      def initialize(config:, logger:, io:)
+      def initialize(config:, logger:, base_class:, io:)
         @problems = []
         @config = config
         @logger = logger
+        @base_class = base_class
         @io = io
       end
 
@@ -110,7 +111,7 @@ module ActiveRecordDoctor
       end
 
       def connection
-        @connection ||= ActiveRecord::Base.connection
+        @connection ||= @base_class.connection
       end
 
       def indexes(table_name)
@@ -156,7 +157,7 @@ module ActiveRecordDoctor
       end
 
       def models
-        ActiveRecord::Base.descendants.sort_by(&:name)
+        @base_class.descendants.sort_by(&:name)
       end
 
       def underscored_name

--- a/lib/active_record_doctor/rake/task.rb
+++ b/lib/active_record_doctor/rake/task.rb
@@ -64,12 +64,16 @@ module ActiveRecordDoctor
       private
 
       def runner
-        @runner ||= ActiveRecordDoctor::Runner.new(config: config, logger: logger)
+        @runner ||= ActiveRecordDoctor::Runner.new(config: config, logger: logger, base_class: base_class)
       end
 
       def config
         @config ||=
           ActiveRecordDoctor.load_config_with_defaults(effective_config_path)
+      end
+
+      def base_class
+        @base_class ||= ENV.fetch("ACTIVE_RECORD_DOCTOR_BASE_CLASS", "ActiveRecord::Base").constantize
       end
 
       def effective_config_path

--- a/lib/active_record_doctor/runner.rb
+++ b/lib/active_record_doctor/runner.rb
@@ -5,9 +5,10 @@ module ActiveRecordDoctor # :nodoc:
   # and an output device for use by detectors.
   class Runner
     # io is injected via constructor parameters to facilitate testing.
-    def initialize(config:, logger:, io: $stdout)
+    def initialize(config:, logger:, base_class: ActiveRecord::Base, io: $stdout)
       @config = config
       @logger = logger
+      @base_class = base_class
       @io = io
     end
 
@@ -16,6 +17,7 @@ module ActiveRecordDoctor # :nodoc:
         ActiveRecordDoctor.detectors.fetch(name).run(
           config: config,
           logger: logger,
+          base_class: base_class,
           io: io
         )
       end
@@ -41,6 +43,6 @@ module ActiveRecordDoctor # :nodoc:
 
     private
 
-    attr_reader :config, :logger, :io
+    attr_reader :config, :logger, :base_class, :io
   end
 end

--- a/test/active_record_doctor/base_class_test.rb
+++ b/test/active_record_doctor/base_class_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class ActiveRecordDoctor::BaseClassTest < Minitest::Test
+  def setup
+    @config = ActiveRecordDoctor.load_config_with_defaults(nil)
+    @logger = ActiveRecordDoctor::Logger::Dummy.new
+    @io = StringIO.new
+  end
+
+  def test_runner_defaults_base_class_to_active_record_base
+    runner = ActiveRecordDoctor::Runner.new(config: @config, logger: @logger, io: @io)
+
+    assert_equal(ActiveRecord::Base, runner.send(:base_class))
+  end
+
+  def test_runner_accepts_custom_base_class
+    runner = ActiveRecordDoctor::Runner.new(
+      config: @config,
+      logger: @logger,
+      base_class: ApplicationRecord,
+      io: @io
+    )
+
+    assert_equal(ApplicationRecord, runner.send(:base_class))
+  end
+
+  def test_detector_models_are_scoped_to_base_class
+    # Anonymous classes avoid polluting the global detector suite; tie to an
+    # existing table so other detectors are not affected by random test order.
+    isolated_root = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+    end
+    isolated_leaf = Class.new(isolated_root) do
+      self.table_name = "schema_migrations"
+    end
+
+    detector = ActiveRecordDoctor::Detectors::MissingForeignKeys.new(
+      config: @config,
+      logger: @logger,
+      base_class: isolated_root,
+      io: @io
+    )
+
+    assert_includes(detector.send(:models), isolated_leaf)
+    refute_includes(detector.send(:models), ApplicationRecord)
+  end
+
+  def test_detector_connection_follows_base_class
+    primary = ActiveRecordDoctor::Detectors::MissingForeignKeys.new(
+      config: @config,
+      logger: @logger,
+      base_class: ApplicationRecord,
+      io: @io
+    )
+
+    secondary = ActiveRecordDoctor::Detectors::MissingForeignKeys.new(
+      config: @config,
+      logger: @logger,
+      base_class: SecondaryRecord,
+      io: @io
+    )
+
+    assert_equal(ApplicationRecord.connection, primary.send(:connection))
+    assert_equal(SecondaryRecord.connection, secondary.send(:connection))
+  end
+
+  def test_rake_task_resolves_base_class_from_environment
+    previous = ENV.fetch("ACTIVE_RECORD_DOCTOR_BASE_CLASS", nil)
+    ENV["ACTIVE_RECORD_DOCTOR_BASE_CLASS"] = "ApplicationRecord"
+
+    task = ActiveRecordDoctor::Rake::Task.new { |t| t.deps = [] }
+
+    assert_equal(ApplicationRecord, task.send(:base_class))
+  ensure
+    restore_env("ACTIVE_RECORD_DOCTOR_BASE_CLASS", previous)
+  end
+
+  def test_rake_task_defaults_base_class_to_active_record_base
+    previous = ENV.fetch("ACTIVE_RECORD_DOCTOR_BASE_CLASS", nil)
+    ENV.delete("ACTIVE_RECORD_DOCTOR_BASE_CLASS")
+
+    task = ActiveRecordDoctor::Rake::Task.new { |t| t.deps = [] }
+
+    assert_equal(ActiveRecord::Base, task.send(:base_class))
+  ensure
+    restore_env("ACTIVE_RECORD_DOCTOR_BASE_CLASS", previous)
+  end
+
+  private
+
+  def restore_env(key, previous)
+    if previous
+      ENV[key] = previous
+    else
+      ENV.delete(key)
+    end
+  end
+end


### PR DESCRIPTION
This change adds a configurable **root model class** (`base_class`) for `ActiveRecordDoctor::Runner` and all detectors, so model discovery and database connection follow the same abstract class you use in the app (e.g. `ApplicationRecord`), including multi-database setups.

- `Runner` accepts `base_class:` (default `ActiveRecord::Base`).
- `Detectors::Base` uses that class for `#connection` and `#models` (descendants).
- Rake tasks read `ACTIVE_RECORD_DOCTOR_BASE_CLASS` and pass it to the runner; the default env string for `constantize` is corrected to `"ActiveRecord::Base"`.
- Regression tests cover Runner, detectors, and Rake behavior; README documents the env var.

Also includes a prior commit constraining **minitest &lt; 6** because `minitest-fork_executor` still hooks `Minitest.run_one_method`, removed in Minitest 6.