### PR TITLE
Fix missing_presence_validation crash when inclusion/exclusion :in is a method name

### DIFF
--- a/lib/active_record_doctor/detectors/missing_presence_validation.rb
+++ b/lib/active_record_doctor/detectors/missing_presence_validation.rb
@@ -93,14 +93,14 @@ module ActiveRecordDoctor
               when ActiveModel::Validations::InclusionValidator
                 validator_items = inclusion_or_exclusion_validator_items(validator)
                 (validator.attributes & attribute_names).present? &&
-                  (validator_items.is_a?(Proc) || validator_items.exclude?(nil))
+                  (dynamic_validator_items?(validator_items) || validator_items.exclude?(nil))
 
               # An exclusion validator ensures the column is not nil if it covers
               # the column and excludes nil as an allowed value explicitly.
               when ActiveModel::Validations::ExclusionValidator
                 validator_items = inclusion_or_exclusion_validator_items(validator)
                 (validator.attributes & attribute_names).present? &&
-                  (validator_items.is_a?(Proc) || validator_items.include?(nil))
+                  (dynamic_validator_items?(validator_items) || validator_items.include?(nil))
 
               end
             end
@@ -170,6 +170,12 @@ module ActiveRecordDoctor
       # Normalizes the list of values passed to an inclusion or exclusion validator.
       def inclusion_or_exclusion_validator_items(validator)
         validator.options[:in] || validator.options[:within] || []
+      end
+
+      # The allowed values can be a Proc or a method name (Symbol) that's resolved
+      # at validation time, so the set of values isn't known statically.
+      def dynamic_validator_items?(validator_items)
+        validator_items.is_a?(Proc) || validator_items.is_a?(Symbol)
       end
 
       # Determines whether the given column is used as a counter cache column by

--- a/test/active_record_doctor/detectors/missing_presence_validation_test.rb
+++ b/test/active_record_doctor/detectors/missing_presence_validation_test.rb
@@ -133,6 +133,20 @@ class ActiveRecordDoctor::Detectors::MissingPresenceValidationTest < Minitest::T
     refute_problems
   end
 
+  def test_non_null_is_not_reported_if_inclusion_in_is_a_method
+    Context.create_table(:users) do |t|
+      t.string :role, null: false
+    end.define_model do
+      validates :role, inclusion: { in: :allowed_roles }
+
+      def allowed_roles
+        ["admin", "user"]
+      end
+    end
+
+    refute_problems
+  end
+
   def test_non_null_boolean_is_reported_if_nil_not_excluded
     Context.create_table(:users) do |t|
       t.boolean :active, null: false


### PR DESCRIPTION
Fixes #238.

`missing_presence_validation` crashes when an inclusion or exclusion validator uses a method name for `:in`, e.g. `validates :status, inclusion: { in: :allowed_statuses }`. In that case `validator.options[:in]` is a Symbol, and the detector calls `.exclude?` / `.include?` on it, raising `NoMethodError: undefined method 'exclude?' for an instance of Symbol`.

A Symbol `:in` is resolved at validation time, just like a Proc, so the allowed values aren't known statically. This treats it the same way the Proc case is already handled instead of assuming the value responds to `include?`/`exclude?`.
